### PR TITLE
split is a deprecated compile error and unused

### DIFF
--- a/src/tui/editor.zig
+++ b/src/tui/editor.zig
@@ -33,7 +33,6 @@ pub const Selection = Buffer.Selection;
 const Allocator = std.mem.Allocator;
 const copy = std.mem.copy;
 const fmt = std.fmt;
-const split = std.mem.split;
 const time = std.time;
 
 const scroll_step_small = 3;


### PR DESCRIPTION
using std.mem.split is a compileError as off this change

https://github.com/ziglang/zig/commit/76fb2b685b202ea665b850338e353c7816f5b2bb