### PR TITLE
vim: change cursor shape when only one cursor

### DIFF
--- a/src/renderer/vaxis/renderer.zig
+++ b/src/renderer/vaxis/renderer.zig
@@ -9,6 +9,7 @@ pub const input = @import("input.zig");
 
 pub const Plane = @import("Plane.zig");
 pub const Cell = @import("Cell.zig");
+pub const CursorShape = vaxis.Cell.CursorShape;
 
 pub const style = @import("style.zig").StyleBits;
 
@@ -352,10 +353,11 @@ pub fn request_mouse_cursor_default(self: *Self, push_or_pop: bool) void {
     if (push_or_pop) self.vx.setMouseShape(.default) else self.vx.setMouseShape(.default);
 }
 
-pub fn cursor_enable(self: *Self, y: c_int, x: c_int) !void {
+pub fn cursor_enable(self: *Self, y: c_int, x: c_int, shape: CursorShape) !void {
     self.vx.screen.cursor_vis = true;
     self.vx.screen.cursor_row = @intCast(y);
     self.vx.screen.cursor_col = @intCast(x);
+    self.vx.screen.cursor_shape = shape;
 }
 
 pub fn cursor_disable(self: *Self) void {

--- a/src/tui/mode/input/vim/insert.zig
+++ b/src/tui/mode/input/vim/insert.zig
@@ -36,6 +36,7 @@ pub fn create(a: Allocator) !tui.Mode {
         .name = root.application_logo ++ "INSERT",
         .description = "vim",
         .line_numbers = if (tui.current().config.vim_insert_gutter_line_numbers_relative) .relative else .absolute,
+        .cursor_shape = .beam,
     };
 }
 

--- a/src/tui/mode/input/vim/normal.zig
+++ b/src/tui/mode/input/vim/normal.zig
@@ -38,6 +38,7 @@ pub fn create(a: Allocator) !tui.Mode {
         .description = "vim",
         .line_numbers = if (tui.current().config.vim_normal_gutter_line_numbers_relative) .relative else .absolute,
         .keybind_hints = &hints,
+        .cursor_shape = .block,
     };
 }
 

--- a/src/tui/mode/input/vim/visual.zig
+++ b/src/tui/mode/input/vim/visual.zig
@@ -38,6 +38,7 @@ pub fn create(a: Allocator) !tui.Mode {
         .description = "vim",
         .line_numbers = if (tui.current().config.vim_visual_gutter_line_numbers_relative) .relative else .absolute,
         .keybind_hints = &hints,
+        .cursor_shape = .underline,
     };
 }
 

--- a/src/tui/tui.zig
+++ b/src/tui/tui.zig
@@ -711,6 +711,7 @@ pub const Mode = struct {
     description: []const u8,
     line_numbers: enum { absolute, relative } = .absolute,
     keybind_hints: ?*const KeybindHints = null,
+    cursor_shape: renderer.CursorShape = .block,
 
     fn deinit(self: *Mode) void {
         self.handler.deinit();


### PR DESCRIPTION
In vim mode, change the cursor shape depending on the mode. This is only
applicable if `enable_terminal_cursor` is set to true and there is only
one cursor in the editor.
