### PR TITLE
open_file: fix possible underflow in delete_to_previous_path_segment

### DIFF
--- a/src/tui/mode/mini/open_file.zig
+++ b/src/tui/mode/mini/open_file.zig
@@ -228,6 +228,10 @@ fn process_project_manager(self: *Self, m: tp.message) !void {
 fn delete_to_previous_path_segment(self: *Self) void {
     self.complete_trigger_count = 0;
     if (self.file_path.items.len == 0) return;
+    if (self.file_path.items.len == 1) {
+        self.file_path.clearRetainingCapacity();
+        return;
+    }
     const path = if (self.file_path.items[self.file_path.items.len - 1] == std.fs.path.sep)
         self.file_path.items[0 .. self.file_path.items.len - 2]
     else


### PR DESCRIPTION
When opening a file, if one writes only "/" then presses ctrl+backspace the "path" slice will end up [0 .. -1].

This crashes in debug build, and possibly in some rare circumstances in release build.