### PR TITLE
Remove unused imports and globals

### DIFF
--- a/src/buffer/Buffer.zig
+++ b/src/buffer/Buffer.zig
@@ -6,7 +6,6 @@ const cwd = std.fs.cwd;
 
 const Self = @This();
 
-const default_leaf_capacity = 64;
 const max_imbalance = 7;
 pub const Root = *const Node;
 pub const unicode = @import("unicode.zig");

--- a/src/buffer/Selection.zig
+++ b/src/buffer/Selection.zig
@@ -1,5 +1,3 @@
-const std = @import("std");
-const Plane = @import("renderer").Plane;
 const Buffer = @import("Buffer.zig");
 const Cursor = @import("Cursor.zig");
 

--- a/src/diff.zig
+++ b/src/diff.zig
@@ -3,7 +3,6 @@ const tp = @import("thespian");
 const dizzy = @import("dizzy");
 const Buffer = @import("Buffer");
 const tracy = @import("tracy");
-const cbor = @import("cbor");
 
 const Self = @This();
 const module_name = @typeName(Self);

--- a/src/log.zig
+++ b/src/log.zig
@@ -1,7 +1,6 @@
 const std = @import("std");
 const tp = @import("thespian");
 
-const deque = std.TailQueue;
 const fba = std.heap.FixedBufferAllocator;
 
 const Self = @This();

--- a/src/renderer/vaxis/renderer.zig
+++ b/src/renderer/vaxis/renderer.zig
@@ -13,7 +13,6 @@ pub const CursorShape = vaxis.Cell.CursorShape;
 
 pub const style = @import("style.zig").StyleBits;
 
-const mod = input.modifier;
 const key = input.key;
 const event_type = input.event_type;
 
@@ -42,12 +41,6 @@ dispatch_event: ?*const fn (ctx: *anyopaque, cbor_msg: []const u8) void = null,
 logger: log.Logger,
 
 loop: Loop,
-
-const Event = union(enum) {
-    key_press: vaxis.Key,
-    winsize: vaxis.Winsize,
-    focus_in,
-};
 
 pub fn init(allocator: std.mem.Allocator, handler_ctx: *anyopaque, no_alternate: bool) !Self {
     const opts: vaxis.Vaxis.Options = .{

--- a/src/service_template.zig
+++ b/src/service_template.zig
@@ -1,6 +1,5 @@
 const std = @import("std");
 const tp = @import("thespian");
-const cbor = @import("cbor");
 const log = @import("log");
 
 pid: ?tp.pid,

--- a/src/tui/Button.zig
+++ b/src/tui/Button.zig
@@ -6,7 +6,6 @@ const key = @import("renderer").input.key;
 const event_type = @import("renderer").input.event_type;
 
 const Widget = @import("Widget.zig");
-const command = @import("command.zig");
 const tui = @import("tui.zig");
 
 pub fn Options(context: type) type {

--- a/src/tui/InputBox.zig
+++ b/src/tui/InputBox.zig
@@ -6,7 +6,6 @@ const key = @import("renderer").input.key;
 const event_type = @import("renderer").input.event_type;
 
 const Widget = @import("Widget.zig");
-const command = @import("command.zig");
 const tui = @import("tui.zig");
 
 pub fn Options(context: type) type {

--- a/src/tui/Menu.zig
+++ b/src/tui/Menu.zig
@@ -1,13 +1,9 @@
 const std = @import("std");
-const tp = @import("thespian");
-
-const planeutils = @import("renderer").planeutils;
 
 const Widget = @import("Widget.zig");
 const WidgetList = @import("WidgetList.zig");
 const EventHandler = @import("EventHandler.zig");
 const Button = @import("Button.zig");
-const tui = @import("tui.zig");
 const scrollbar_v = @import("scrollbar_v.zig");
 
 pub const Container = WidgetList;

--- a/src/tui/editor.zig
+++ b/src/tui/editor.zig
@@ -25,21 +25,15 @@ const WidgetList = @import("WidgetList.zig");
 const command = @import("command.zig");
 const tui = @import("tui.zig");
 
-const module = @This();
-
 pub const Cursor = Buffer.Cursor;
 pub const View = Buffer.View;
 pub const Selection = Buffer.Selection;
 
 const Allocator = std.mem.Allocator;
-const copy = std.mem.copy;
-const fmt = std.fmt;
 const time = std.time;
 
 const scroll_step_small = 3;
-const scroll_page_ratio = 3;
 const scroll_cursor_min_border_distance = 5;
-const scroll_cursor_min_border_distance_mouse = 1;
 
 const double_click_time_ms = 350;
 pub const max_matches = if (builtin.mode == std.builtin.OptimizeMode.Debug) 10_000 else 100_000;

--- a/src/tui/editor_gutter.zig
+++ b/src/tui/editor_gutter.zig
@@ -12,7 +12,6 @@ const key = @import("renderer").input.key;
 const event_type = @import("renderer").input.event_type;
 
 const Widget = @import("Widget.zig");
-const WidgetList = @import("WidgetList.zig");
 const EventHandler = @import("EventHandler.zig");
 const MessageFilter = @import("MessageFilter.zig");
 const tui = @import("tui.zig");

--- a/src/tui/filelist_view.zig
+++ b/src/tui/filelist_view.zig
@@ -1,30 +1,20 @@
 const std = @import("std");
-const eql = @import("std").mem.eql;
-const fmt = @import("std").fmt;
-const time = @import("std").time;
 const cbor = @import("cbor");
 const Allocator = @import("std").mem.Allocator;
-const Mutex = @import("std").Thread.Mutex;
-const ArrayList = @import("std").ArrayList;
 
 const Plane = @import("renderer").Plane;
 const tp = @import("thespian");
 const log = @import("log");
-const key = @import("renderer").input.key;
-const event_type = @import("renderer").input.event_type;
 const root = @import("root");
 
 const command = @import("command.zig");
 const tui = @import("tui.zig");
 const Widget = @import("Widget.zig");
-const MessageFilter = @import("MessageFilter.zig");
 const Menu = @import("Menu.zig");
 const EventHandler = @import("EventHandler.zig");
 const Button = @import("Button.zig");
 const scrollbar_v = @import("scrollbar_v.zig");
 const editor = @import("editor.zig");
-
-const escape = fmt.fmtSliceEscapeLower;
 
 pub const name = @typeName(Self);
 

--- a/src/tui/home.zig
+++ b/src/tui/home.zig
@@ -2,13 +2,9 @@ const std = @import("std");
 const tp = @import("thespian");
 
 const Plane = @import("renderer").Plane;
-const planeutils = @import("renderer").planeutils;
-const channels_ = @import("renderer").channels;
-const style_ = @import("renderer").style;
 const root = @import("root");
 
 const Widget = @import("Widget.zig");
-const WidgetList = @import("WidgetList.zig");
 const Button = @import("Button.zig");
 const Menu = @import("Menu.zig");
 const tui = @import("tui.zig");

--- a/src/tui/inputview.zig
+++ b/src/tui/inputview.zig
@@ -1,8 +1,6 @@
 const eql = @import("std").mem.eql;
-const fmt = @import("std").fmt;
 const time = @import("std").time;
 const Allocator = @import("std").mem.Allocator;
-const Mutex = @import("std").Thread.Mutex;
 const ArrayList = @import("std").ArrayList;
 
 const tp = @import("thespian");

--- a/src/tui/inspector_view.zig
+++ b/src/tui/inspector_view.zig
@@ -1,6 +1,3 @@
-const eql = @import("std").mem.eql;
-const fmt = @import("std").fmt;
-const time = @import("std").time;
 const Allocator = @import("std").mem.Allocator;
 
 const tp = @import("thespian");

--- a/src/tui/logview.zig
+++ b/src/tui/logview.zig
@@ -2,17 +2,13 @@ const eql = @import("std").mem.eql;
 const fmt = @import("std").fmt;
 const time = @import("std").time;
 const Allocator = @import("std").mem.Allocator;
-const Mutex = @import("std").Thread.Mutex;
 const ArrayList = @import("std").ArrayList;
 
 const tp = @import("thespian");
-const log = @import("log");
 
 const Plane = @import("renderer").Plane;
 
-const tui = @import("tui.zig");
 const Widget = @import("Widget.zig");
-const MessageFilter = @import("MessageFilter.zig");
 
 const escape = fmt.fmtSliceEscapeLower;
 

--- a/src/tui/mainview.zig
+++ b/src/tui/mainview.zig
@@ -46,15 +46,6 @@ find_in_files_done: bool = false,
 file_list_type: FileListType = .find_in_files,
 panel_height: ?usize = null,
 
-const NavState = struct {
-    time: i64 = 0,
-    lines: usize = 0,
-    rows: usize = 0,
-    row: usize = 0,
-    col: usize = 0,
-    matches: usize = 0,
-};
-
 const FileListType = enum {
     diagnostics,
     references,

--- a/src/tui/mode/input/flow.zig
+++ b/src/tui/mode/input/flow.zig
@@ -12,7 +12,6 @@ const EventHandler = @import("../../EventHandler.zig");
 
 const Allocator = @import("std").mem.Allocator;
 const ArrayList = @import("std").ArrayList;
-const json = @import("std").json;
 const eql = @import("std").mem.eql;
 
 const Self = @This();

--- a/src/tui/mode/input/helix/insert.zig
+++ b/src/tui/mode/input/helix/insert.zig
@@ -11,7 +11,6 @@ const EventHandler = @import("../../../EventHandler.zig");
 
 const Allocator = @import("std").mem.Allocator;
 const ArrayList = @import("std").ArrayList;
-const json = @import("std").json;
 const eql = @import("std").mem.eql;
 
 const Self = @This();

--- a/src/tui/mode/input/helix/normal.zig
+++ b/src/tui/mode/input/helix/normal.zig
@@ -11,7 +11,6 @@ const EventHandler = @import("../../../EventHandler.zig");
 
 const Allocator = @import("std").mem.Allocator;
 const ArrayList = @import("std").ArrayList;
-const json = @import("std").json;
 const eql = @import("std").mem.eql;
 
 const Self = @This();

--- a/src/tui/mode/input/helix/select.zig
+++ b/src/tui/mode/input/helix/select.zig
@@ -11,7 +11,6 @@ const EventHandler = @import("../../../EventHandler.zig");
 
 const Allocator = @import("std").mem.Allocator;
 const ArrayList = @import("std").ArrayList;
-const json = @import("std").json;
 const eql = @import("std").mem.eql;
 
 const Self = @This();

--- a/src/tui/mode/input/vim/insert.zig
+++ b/src/tui/mode/input/vim/insert.zig
@@ -11,7 +11,6 @@ const EventHandler = @import("../../../EventHandler.zig");
 
 const Allocator = @import("std").mem.Allocator;
 const ArrayList = @import("std").ArrayList;
-const json = @import("std").json;
 const eql = @import("std").mem.eql;
 
 const Self = @This();

--- a/src/tui/mode/input/vim/normal.zig
+++ b/src/tui/mode/input/vim/normal.zig
@@ -11,7 +11,6 @@ const EventHandler = @import("../../../EventHandler.zig");
 
 const Allocator = @import("std").mem.Allocator;
 const ArrayList = @import("std").ArrayList;
-const json = @import("std").json;
 const eql = @import("std").mem.eql;
 
 const Self = @This();

--- a/src/tui/mode/input/vim/visual.zig
+++ b/src/tui/mode/input/vim/visual.zig
@@ -11,7 +11,6 @@ const EventHandler = @import("../../../EventHandler.zig");
 
 const Allocator = @import("std").mem.Allocator;
 const ArrayList = @import("std").ArrayList;
-const json = @import("std").json;
 const eql = @import("std").mem.eql;
 
 const Self = @This();

--- a/src/tui/mode/mini/file_browser.zig
+++ b/src/tui/mode/mini/file_browser.zig
@@ -10,7 +10,6 @@ const ucs32_to_utf8 = @import("renderer").ucs32_to_utf8;
 const project_manager = @import("project_manager");
 
 const tui = @import("../../tui.zig");
-const mainview = @import("../../mainview.zig");
 const command = @import("../../command.zig");
 const EventHandler = @import("../../EventHandler.zig");
 const MessageFilter = @import("../../MessageFilter.zig");

--- a/src/tui/mode/mini/find.zig
+++ b/src/tui/mode/mini/find.zig
@@ -12,7 +12,6 @@ const EventHandler = @import("../../EventHandler.zig");
 const ed = @import("../../editor.zig");
 
 const Allocator = @import("std").mem.Allocator;
-const json = @import("std").json;
 const eql = @import("std").mem.eql;
 const ArrayList = @import("std").ArrayList;
 
@@ -167,8 +166,6 @@ fn insert_code_point(self: *Self, c: u32) !void {
 fn insert_bytes(self: *Self, bytes: []const u8) !void {
     try self.input.appendSlice(bytes);
 }
-
-var find_cmd_id: ?command.ID = null;
 
 fn flush_input(self: *Self) !void {
     if (self.input.items.len > 0) {

--- a/src/tui/mode/mini/find_in_files.zig
+++ b/src/tui/mode/mini/find_in_files.zig
@@ -9,10 +9,8 @@ const tui = @import("../../tui.zig");
 const mainview = @import("../../mainview.zig");
 const command = @import("../../command.zig");
 const EventHandler = @import("../../EventHandler.zig");
-const ed = @import("../../editor.zig");
 
 const Allocator = @import("std").mem.Allocator;
-const json = @import("std").json;
 const eql = @import("std").mem.eql;
 
 const Self = @This();
@@ -167,8 +165,6 @@ fn insert_bytes(self: *Self, bytes: []const u8) !void {
     @memcpy(self.buf[self.input.len..newlen], bytes);
     self.input = self.buf[0..newlen];
 }
-
-var find_cmd_id: ?command.ID = null;
 
 fn flush_input(self: *Self) !void {
     if (self.input.len > 2) {

--- a/src/tui/mode/mini/goto.zig
+++ b/src/tui/mode/mini/goto.zig
@@ -10,8 +10,6 @@ const command = @import("../../command.zig");
 const EventHandler = @import("../../EventHandler.zig");
 
 const Allocator = @import("std").mem.Allocator;
-const json = @import("std").json;
-const eql = @import("std").mem.eql;
 const fmt = @import("std").fmt;
 
 const Self = @This();

--- a/src/tui/mode/mini/move_to_char.zig
+++ b/src/tui/mode/mini/move_to_char.zig
@@ -11,9 +11,6 @@ const command = @import("../../command.zig");
 const EventHandler = @import("../../EventHandler.zig");
 
 const Allocator = @import("std").mem.Allocator;
-const json = @import("std").json;
-const eql = @import("std").mem.eql;
-const fmt = @import("std").fmt;
 
 const Self = @This();
 

--- a/src/tui/mode/mini/open_file.zig
+++ b/src/tui/mode/mini/open_file.zig
@@ -1,19 +1,11 @@
 const std = @import("std");
 const tp = @import("thespian");
-const log = @import("log");
 const root = @import("root");
 
-const key = @import("renderer").input.key;
-const mod = @import("renderer").input.modifier;
-const event_type = @import("renderer").input.event_type;
-const ucs32_to_utf8 = @import("renderer").ucs32_to_utf8;
-const project_manager = @import("project_manager");
 
 const tui = @import("../../tui.zig");
 const mainview = @import("../../mainview.zig");
 const command = @import("../../command.zig");
-const EventHandler = @import("../../EventHandler.zig");
-const MessageFilter = @import("../../MessageFilter.zig");
 
 pub const Type = @import("file_browser.zig").Create(@This());
 

--- a/src/tui/mode/mini/save_as.zig
+++ b/src/tui/mode/mini/save_as.zig
@@ -1,19 +1,11 @@
 const std = @import("std");
 const tp = @import("thespian");
-const log = @import("log");
 const root = @import("root");
 
-const key = @import("renderer").input.key;
-const mod = @import("renderer").input.modifier;
-const event_type = @import("renderer").input.event_type;
-const ucs32_to_utf8 = @import("renderer").ucs32_to_utf8;
-const project_manager = @import("project_manager");
 
 const tui = @import("../../tui.zig");
 const mainview = @import("../../mainview.zig");
 const command = @import("../../command.zig");
-const EventHandler = @import("../../EventHandler.zig");
-const MessageFilter = @import("../../MessageFilter.zig");
 
 pub const Type = @import("file_browser.zig").Create(@This());
 

--- a/src/tui/mode/overlay/open_recent.zig
+++ b/src/tui/mode/overlay/open_recent.zig
@@ -5,7 +5,6 @@ const cbor = @import("cbor");
 const root = @import("root");
 
 const Plane = @import("renderer").Plane;
-const planeutils = @import("renderer").planeutils;
 const key = @import("renderer").input.key;
 const mod = @import("renderer").input.modifier;
 const event_type = @import("renderer").input.event_type;

--- a/src/tui/mode/overlay/open_recent_project.zig
+++ b/src/tui/mode/overlay/open_recent_project.zig
@@ -3,8 +3,6 @@ const cbor = @import("cbor");
 const tp = @import("thespian");
 const project_manager = @import("project_manager");
 
-const Widget = @import("../../Widget.zig");
-const tui = @import("../../tui.zig");
 
 pub const Type = @import("palette.zig").Create(@This());
 

--- a/src/tui/mode/overlay/palette.zig
+++ b/src/tui/mode/overlay/palette.zig
@@ -13,7 +13,6 @@ const ucs32_to_utf8 = @import("renderer").ucs32_to_utf8;
 const tui = @import("../../tui.zig");
 const command = @import("../../command.zig");
 const EventHandler = @import("../../EventHandler.zig");
-const WidgetList = @import("../../WidgetList.zig");
 const Button = @import("../../Button.zig");
 const InputBox = @import("../../InputBox.zig");
 const Widget = @import("../../Widget.zig");

--- a/src/tui/scrollbar_v.zig
+++ b/src/tui/scrollbar_v.zig
@@ -8,7 +8,6 @@ const event_type = @import("renderer").input.event_type;
 
 const Widget = @import("Widget.zig");
 const EventHandler = @import("EventHandler.zig");
-const tui = @import("tui.zig");
 
 plane: Plane,
 pos_scrn: u32 = 0,

--- a/src/tui/status/bar.zig
+++ b/src/tui/status/bar.zig
@@ -3,9 +3,6 @@ const std = @import("std");
 const status_widget = @import("widget.zig");
 const Widget = @import("../Widget.zig");
 const WidgetList = @import("../WidgetList.zig");
-const tui = @import("../tui.zig");
-
-const Self = @This();
 
 pub const Style = enum { none, grip };
 

--- a/src/tui/status/clock.zig
+++ b/src/tui/status/clock.zig
@@ -1,6 +1,5 @@
 const std = @import("std");
 const tp = @import("thespian");
-const log = @import("log");
 const zeit = @import("zeit");
 
 const Plane = @import("renderer").Plane;
@@ -8,8 +7,6 @@ const Plane = @import("renderer").Plane;
 const Widget = @import("../Widget.zig");
 const MessageFilter = @import("../MessageFilter.zig");
 const tui = @import("../tui.zig");
-const mainview = @import("../mainview.zig");
-const logview = @import("../logview.zig");
 
 allocator: std.mem.Allocator,
 plane: Plane,
@@ -17,14 +14,7 @@ tick_timer: ?tp.Cancellable = null,
 on_event: ?Widget.EventHandler,
 tz: zeit.timezone.TimeZone,
 
-const message_display_time_seconds = 2;
-const error_display_time_seconds = 4;
 const Self = @This();
-
-const Level = enum {
-    info,
-    err,
-};
 
 pub fn create(allocator: std.mem.Allocator, parent: Plane, event_handler: ?Widget.EventHandler) @import("widget.zig").CreateError!Widget {
     var env = std.process.getEnvMap(allocator) catch |e| return tp.exit_error(e, @errorReturnTrace());

--- a/src/tui/status/diagstate.zig
+++ b/src/tui/status/diagstate.zig
@@ -1,13 +1,11 @@
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 const tp = @import("thespian");
-const tracy = @import("tracy");
 
 const Plane = @import("renderer").Plane;
 
 const Widget = @import("../Widget.zig");
 const Button = @import("../Button.zig");
-const tui = @import("../tui.zig");
 const command = @import("../command.zig");
 
 errors: usize = 0,

--- a/src/tui/status/filestate.zig
+++ b/src/tui/status/filestate.zig
@@ -3,7 +3,6 @@ const Allocator = std.mem.Allocator;
 const tp = @import("thespian");
 const tracy = @import("tracy");
 const root = @import("root");
-const builtin = @import("builtin");
 
 const Plane = @import("renderer").Plane;
 const style = @import("renderer").style;

--- a/src/tui/status/linenumstate.zig
+++ b/src/tui/status/linenumstate.zig
@@ -1,13 +1,11 @@
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 const tp = @import("thespian");
-const tracy = @import("tracy");
 
 const Plane = @import("renderer").Plane;
 
 const Widget = @import("../Widget.zig");
 const Button = @import("../Button.zig");
-const tui = @import("../tui.zig");
 const command = @import("../command.zig");
 
 line: usize = 0,

--- a/src/tui/status/minilog.zig
+++ b/src/tui/status/minilog.zig
@@ -7,7 +7,6 @@ const Plane = @import("renderer").Plane;
 const Widget = @import("../Widget.zig");
 const MessageFilter = @import("../MessageFilter.zig");
 const tui = @import("../tui.zig");
-const mainview = @import("../mainview.zig");
 const logview = @import("../logview.zig");
 
 plane: Plane,

--- a/src/tui/status/modestate.zig
+++ b/src/tui/status/modestate.zig
@@ -1,17 +1,12 @@
 const std = @import("std");
 const Allocator = std.mem.Allocator;
-const tp = @import("thespian");
-const tracy = @import("tracy");
-const root = @import("root");
 
 const Plane = @import("renderer").Plane;
 const style = @import("renderer").style;
 
 const Widget = @import("../Widget.zig");
-const Menu = @import("../Menu.zig");
 const Button = @import("../Button.zig");
 const command = @import("../command.zig");
-const ed = @import("../editor.zig");
 const tui = @import("../tui.zig");
 const CreateError = @import("widget.zig").CreateError;
 

--- a/src/tui/status/selectionstate.zig
+++ b/src/tui/status/selectionstate.zig
@@ -7,7 +7,6 @@ const Plane = @import("renderer").Plane;
 
 const Widget = @import("../Widget.zig");
 const ed = @import("../editor.zig");
-const tui = @import("../tui.zig");
 
 plane: Plane,
 matches: usize = 0,

--- a/src/tui/tui.zig
+++ b/src/tui/tui.zig
@@ -3,7 +3,6 @@ const tp = @import("thespian");
 const log = @import("log");
 const config = @import("config");
 const project_manager = @import("project_manager");
-const build_options = @import("build_options");
 const root = @import("root");
 const tracy = @import("tracy");
 const builtin = @import("builtin");
@@ -11,19 +10,12 @@ const builtin = @import("builtin");
 pub const renderer = @import("renderer");
 
 const command = @import("command.zig");
-const WidgetStack = @import("WidgetStack.zig");
 const Widget = @import("Widget.zig");
 const MessageFilter = @import("MessageFilter.zig");
 const EventHandler = @import("EventHandler.zig");
 const mainview = @import("mainview.zig");
 
 const Allocator = std.mem.Allocator;
-const ArrayList = std.ArrayList;
-const eql = std.mem.eql;
-const STDIN_FILENO = std.os.STDIN_FILENO;
-const Timer = std.time.Timer;
-const Mutex = std.Thread.Mutex;
-const maxInt = std.math.maxInt;
 
 allocator: Allocator,
 rdr: renderer,


### PR DESCRIPTION
I'm building a little Zig [unused import remover](https://github.com/tusharsadhwani/zigimports) tool, I used your repository to help debug some edge cases, and this output seems to compile just fine. Leaving this PR here incase you find it useful.