### PR TITLE
feat: nix flake via `zig2nix`

### DIFF
--- a/build.zig.zon2json-lock
+++ b/build.zig.zon2json-lock
@@ -1,0 +1,82 @@
+{
+  "12207ee987ce045596cb992cfb15b0d6d9456e50d4721c3061c69dabc2962053644d": {
+    "name": "clap",
+    "url": "https://github.com/Hejsil/zig-clap/archive/c0193e9247335a6c1688b946325060289405de2a.tar.gz",
+    "hash": "sha256-mcyQakRtIqL8d3ZEF9dSCG+OhWjJ+QydwoBxMTxhpQI="
+  },
+  "1220a2c8f8db1b5265458ac967ea1f7cc0a8ddcd1d774df3b73d86c4f529aadbfb94": {
+    "name": "tracy",
+    "url": "https://github.com/neurocyte/zig-tracy/archive/58999b786089e5319dd0707f6afbfca04c6340e7.tar.gz",
+    "hash": "sha256-4q1UD2hRtp9mUPL5wIKzk8AhnAoVkl9xpaUN5sp4mWA="
+  },
+  "12202aac930cebaf2b57f443cacc2483478580a72f1316b4f0a720ddd91246fce69d": {
+    "name": "tracy_src",
+    "url": "https://github.com/wolfpld/tracy/archive/refs/tags/v0.10.tar.gz",
+    "hash": "sha256-p2AX2Sjz8nJ1QPuVDt07c2yql7Etu05e3OZlQsvqZgA="
+  },
+  "1220220dbc7fe91c1c54438193ca765cebbcb7d58f35cdcaee404a9d2245a42a4362": {
+    "name": "dizzy",
+    "url": "https://github.com/neurocyte/dizzy/archive/455d18369cbb2a0458ba70be919cd378338d695e.tar.gz",
+    "hash": "sha256-PKCqS8/sEieEA3ZONEsBHq+am02JRHG9waYzn2GnYgI="
+  },
+  "12206feb723c41340acfe574b16f98a90e3af1f2662850ee2904ec0facb9dc5f0eef": {
+    "name": "thespian",
+    "url": "https://github.com/neurocyte/thespian/archive/6e65fa623a45a4925875955aeb45e5cb0b5f7a68.tar.gz",
+    "hash": "sha256-fczNOm0qy1k+zW/iBzWRRSP+NIycBvBQ9phlE8jxesg="
+  },
+  "1220c85e0d9438ec518849c84e3ea66633a0e191e49c4ae4bbb3bc46626cd8dfad75": {
+    "name": "asio",
+    "url": "https://github.com/neurocyte/asio/archive/b9c9c23ef2e6f11b6123535ec33e5a23ed0c59da.tar.gz",
+    "hash": "sha256-tD9lxE6RRAptBE9suZA4ANpT5x/B3e4YINay9Se78XY="
+  },
+  "12208fa20104c3311e97c20e70d0a81a257f2c2e24f627616984e38dda309749b29a": {
+    "name": "themes",
+    "url": "https://github.com/neurocyte/flow-themes/releases/download/master-803da089c5a0fc3b4513a7c34afe9bdaff83efdc/flow-themes.tar.gz",
+    "hash": "sha256-3CNMCS+axnBUv5tPDvgoWo/Pdry62d3+FjQeQjIyXws="
+  },
+  "122019f077d09686b1ec47928ca2b4bf264422f3a27afc5b49dafb0129a4ceca0d01": {
+    "name": "fuzzig",
+    "url": "https://github.com/fjebaker/fuzzig/archive/0fd156d5097365151e85a85eef9d8cf0eebe7b00.tar.gz",
+    "hash": "sha256-XVOKqHX2X8HvRDJgnqVEPN/A0hFvCk8Fgsss0CKInYQ="
+  },
+  "12206bacf76425efb2bda37c77b05e2ce13a18aa152d3b2264d2bcadb0941ba93ffc": {
+    "name": "vaxis",
+    "url": "https://github.com/neurocyte/libvaxis/archive/e1e3c61cdfa35a68e747685d1a245aa1d81d88f4.tar.gz",
+    "hash": "sha256-ry+rqiSEnzNYHBbe8WRIUOTBv/paZk1CD5aNRTdiS7E="
+  },
+  "1220dd654ef941fc76fd96f9ec6adadf83f69b9887a0d3f4ee5ac0a1a3e11be35cf5": {
+    "name": "zigimg",
+    "url": "git+https://github.com/zigimg/zigimg#3a667bdb3d7f0955a5a51c8468eac83210c1439e",
+    "hash": "sha256-oLf3YH3yeg4ikVO/GahMCDRMTU31AHkfSnF4rt7xTKo="
+  },
+  "12200d1ce5f9733a9437415d85665ad5fbc85a4d27689fd337fecad8014acffe3aa5": {
+    "name": "zg",
+    "url": "git+https://codeberg.org/dude_the_builder/zg?ref=master#689ab6b83d08c02724b99d199d650ff731250998",
+    "hash": "sha256-mFfzEh/VqNN5rqm4bUg3mgFZZBvVCD6hzxychWXaUqA="
+  },
+  "12207b7a5b538ffb7fb18f954ae17d2f8490b6e3778a9e30564ad82c58ee8da52361": {
+    "name": "libxev",
+    "url": "git+https://github.com/mitchellh/libxev#f6a672a78436d8efee1aa847a43a900ad773618b",
+    "hash": "sha256-NCRu+2UixKsm+tJMQiPyzAYL/kiKn4HFbJq3wpTF34Q="
+  },
+  "1220a55aedabdd10578d0c514719ea39ae1bc6d7ed990f508dc100db7f0ccf391437": {
+    "name": "aio",
+    "url": "git+https://github.com/Cloudef/zig-aio#b5a407344379508466c5dcbe4c74438a6166e2ca",
+    "hash": "sha256-OvM4CA2w9v2XpjAV26CjsLIWOILOQm89xaEwitYpciw="
+  },
+  "1220da4cab188b7b0e351de67626ca0dcadceddd16ca5997cfb578697f0525a59dac": {
+    "name": "zigwin32",
+    "url": "git+https://github.com/marlersoft/zigwin32.git#4a78e716ae6496f52d9ddaf4fda2c4bb692631cd",
+    "hash": "sha256-/XvkZPxoq2oeEWREX0dDLdVro4NsCBsMHWKcytaD4Rg="
+  },
+  "1220755ea2a5aa6bb3713437aaafefd44812169fe43f1da755c3ee6101b85940f441": {
+    "name": "zeit",
+    "url": "https://github.com/rockorager/zeit/archive/9cca8ec620a54c3b07cd249f25e5bcb3153d03d7.tar.gz",
+    "hash": "sha256-4bxyQKbVUtYzZixUq2d+iiSPGkcwg+dG4WLaDYYQzn8="
+  },
+  "12208efbfead8c57adeabbd2293d6ed19e00f769e1d8aba0d544270479587c9f694a": {
+    "name": "tree-sitter",
+    "url": "https://github.com/neurocyte/tree-sitter/releases/download/master-876cc5a125cb822d44a9f94f6bde64fac66272ce/source.tar.gz",
+    "hash": "sha256-6WsJClMEOhULIjdyhxOI3jV9nAPftY5J9FM+iM7/3P4="
+  }
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,78 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1726108120,
+        "narHash": "sha256-Ji5wO1lLG99grI0qCRb6FyRPpH9tfdfD1QP/r7IlgfM=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "111ed8812c10d7dc3017de46cbf509600c93f551",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "zig2nix": "zig2nix"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "zig2nix": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1727227867,
+        "narHash": "sha256-X+AHru7MhbU9Vhx+KRbn1jdHBVXjNR25t7CLxs7h7Vk=",
+        "owner": "Cloudef",
+        "repo": "zig2nix",
+        "rev": "998acf847abedff85f7f5d8417f0757006a13f07",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Cloudef",
+        "repo": "zig2nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,93 @@
+{
+  description = "flow project flake";
+
+  inputs = {
+    zig2nix.url = "github:Cloudef/zig2nix";
+  };
+
+  outputs = {zig2nix, ...}: let
+    flake-utils = zig2nix.inputs.flake-utils;
+  in (flake-utils.lib.eachDefaultSystem (system: let
+    # Zig flake helper
+    # Check the flake.nix in zig2nix project for more options:
+    # <https://github.com/Cloudef/zig2nix/blob/master/flake.nix>
+    env = zig2nix.outputs.zig-env.${system} {};
+    system-triple = env.lib.zigTripleFromString system;
+  in
+    with builtins;
+    with env.lib;
+    with env.pkgs.lib; rec {
+      # nix build .#target.{zig-target}
+      # e.g. nix build .#target.x86_64-linux-gnu
+      packages.target = genAttrs allTargetTriples (target:
+        env.packageForTarget target ({
+            src = cleanSource ./.;
+
+            nativeBuildInputs = with env.pkgs; [];
+            buildInputs = with env.pkgsForTarget target; [];
+
+            # Smaller binaries and avoids shipping glibc.
+            zigPreferMusl = true;
+
+            # This disables LD_LIBRARY_PATH mangling, binary patching etc...
+            # The package won't be usable inside nix.
+            zigDisableWrap = true;
+          }
+          // optionalAttrs (!pathExists ./build.zig.zon) {
+            pname = "flow";
+            version = "0.1.0";
+          }));
+
+      # nix build .
+      packages.default = packages.target.${system-triple}.override {
+        # Prefer nix friendly settings.
+        zigPreferMusl = false;
+        zigDisableWrap = false;
+      };
+
+      # For bundling with nix bundle for running outside of nix
+      # example: https://github.com/ralismark/nix-appimage
+      apps.bundle.target = genAttrs allTargetTriples (target: let
+        pkg = packages.target.${target};
+      in {
+        type = "app";
+        program = "${pkg}/bin/default";
+      });
+
+      # default bundle
+      apps.bundle.default = apps.bundle.target.${system-triple};
+
+      # nix run .
+      # apps.default = env.app [] "zig build run -- \"$@\"";
+      apps.default = let
+        pkg = packages.target.${system-triple};
+      in {
+        type = "app";
+        program = "${pkg}/bin/flow";
+      };
+
+      # nix run .#build
+      apps.build = env.app [] "zig build \"$@\"";
+
+      # nix run .#test
+      apps.test = env.app [] "zig build test -- \"$@\"";
+
+      # nix run .#docs
+      apps.docs = env.app [] "zig build docs -- \"$@\"";
+
+      # nix run .#deps
+      apps.deps = env.showExternalDeps;
+
+      # nix run .#zon2json
+      apps.zon2json = env.app [env.zon2json] "zon2json \"$@\"";
+
+      # nix run .#zon2json-lock
+      apps.zon2json-lock = env.app [env.zon2json-lock] "zon2json-lock \"$@\"";
+
+      # nix run .#zon2nix
+      apps.zon2nix = env.app [env.zon2nix] "zon2nix \"$@\"";
+
+      # nix develop
+      devShells.default = env.mkShell {};
+    }));
+}

--- a/flake.nix
+++ b/flake.nix
@@ -69,24 +69,6 @@
       # nix run .#build
       apps.build = env.app [] "zig build \"$@\"";
 
-      # nix run .#test
-      apps.test = env.app [] "zig build test -- \"$@\"";
-
-      # nix run .#docs
-      apps.docs = env.app [] "zig build docs -- \"$@\"";
-
-      # nix run .#deps
-      apps.deps = env.showExternalDeps;
-
-      # nix run .#zon2json
-      apps.zon2json = env.app [env.zon2json] "zon2json \"$@\"";
-
-      # nix run .#zon2json-lock
-      apps.zon2json-lock = env.app [env.zon2json-lock] "zon2json-lock \"$@\"";
-
-      # nix run .#zon2nix
-      apps.zon2nix = env.app [env.zon2nix] "zon2nix \"$@\"";
-
       # nix develop
       devShells.default = env.mkShell {};
     }));

--- a/flake.nix
+++ b/flake.nix
@@ -55,8 +55,5 @@
 
       # nix run .#build
       apps.build = env.app [] "zig build \"$@\"";
-
-      # nix develop
-      devShells.default = env.mkShell {};
     }));
 }

--- a/flake.nix
+++ b/flake.nix
@@ -45,20 +45,7 @@
         zigDisableWrap = false;
       };
 
-      # For bundling with nix bundle for running outside of nix
-      # example: https://github.com/ralismark/nix-appimage
-      apps.bundle.target = genAttrs allTargetTriples (target: let
-        pkg = packages.target.${target};
-      in {
-        type = "app";
-        program = "${pkg}/bin/default";
-      });
-
-      # default bundle
-      apps.bundle.default = apps.bundle.target.${system-triple};
-
       # nix run .
-      # apps.default = env.app [] "zig build run -- \"$@\"";
       apps.default = let
         pkg = packages.target.${system-triple};
       in {


### PR DESCRIPTION
This PR adds a `flake.nix` file that allows nix users to build and run the flow terminal app with a single command: `nix run github:neurocyte/flow`

The flake has been tested to work on my m1 macbook air against my fork via the command: `nix run github:aidanaden/flow`

PS. I'm quite new to nix so there may be optimisations i'm missing out on, but this flake format has been working on my zig projects so far, it'd also be great if someone could help test if this works on other platforms (linux/windows)