### PR TITLE
add vim normal hover keybind and fix typo

### DIFF
--- a/src/tui/mode/input/helix/insert.zig
+++ b/src/tui/mode/input/helix/insert.zig
@@ -315,7 +315,7 @@ const cmds_ = struct {
     pub fn q(self: *Self, _: Ctx) Result {
         try self.cmd("quit", .{});
     }
-    pub const q_meta = .{ .description = "w (quit)" };
+    pub const q_meta = .{ .description = "q (quit)" };
 
     pub fn @"q!"(self: *Self, _: Ctx) Result {
         try self.cmd("quit_without_saving", .{});

--- a/src/tui/mode/input/helix/normal.zig
+++ b/src/tui/mode/input/helix/normal.zig
@@ -667,7 +667,7 @@ const cmds_ = struct {
     pub fn q(self: *Self, _: Ctx) Result {
         try self.cmd("quit", .{});
     }
-    pub const q_meta = .{ .description = "w (quit)" };
+    pub const q_meta = .{ .description = "q (quit)" };
 
     pub fn @"q!"(self: *Self, _: Ctx) Result {
         try self.cmd("quit_without_saving", .{});

--- a/src/tui/mode/input/helix/select.zig
+++ b/src/tui/mode/input/helix/select.zig
@@ -667,7 +667,7 @@ const cmds_ = struct {
     pub fn q(self: *Self, _: Ctx) Result {
         try self.cmd("quit", .{});
     }
-    pub const q_meta = .{ .description = "w (quit)" };
+    pub const q_meta = .{ .description = "q (quit)" };
 
     pub fn @"q!"(self: *Self, _: Ctx) Result {
         try self.cmd("quit_without_saving", .{});

--- a/src/tui/mode/input/vim/insert.zig
+++ b/src/tui/mode/input/vim/insert.zig
@@ -315,7 +315,7 @@ const cmds_ = struct {
     pub fn q(self: *Self, _: Ctx) Result {
         try self.cmd("quit", .{});
     }
-    pub const q_meta = .{ .description = "w (quit)" };
+    pub const q_meta = .{ .description = "q (quit)" };
 
     pub fn @"q!"(self: *Self, _: Ctx) Result {
         try self.cmd("quit_without_saving", .{});

--- a/src/tui/mode/input/vim/normal.zig
+++ b/src/tui/mode/input/vim/normal.zig
@@ -209,6 +209,7 @@ fn mapPress(self: *Self, keypress: u32, egc: u32, modifiers: u32) !void {
             },
 
             'o' => self.seq(.{ "smart_insert_line_before", "enter_mode" }, command.fmt(.{"vim/insert"})),
+            'k' => self.cmd("hover", .{}),
 
             else => {},
         },
@@ -631,7 +632,7 @@ const cmds_ = struct {
     pub fn q(self: *Self, _: Ctx) Result {
         try self.cmd("quit", .{});
     }
-    pub const q_meta = .{ .description = "w (quit)" };
+    pub const q_meta = .{ .description = "q (quit)" };
 
     pub fn @"q!"(self: *Self, _: Ctx) Result {
         try self.cmd("quit_without_saving", .{});

--- a/src/tui/mode/input/vim/visual.zig
+++ b/src/tui/mode/input/vim/visual.zig
@@ -580,7 +580,7 @@ const cmds_ = struct {
     pub fn q(self: *Self, _: Ctx) Result {
         try self.cmd("quit", .{});
     }
-    pub const q_meta = .{ .description = "w (quit)" };
+    pub const q_meta = .{ .description = "q (quit)" };
 
     pub fn @"q!"(self: *Self, _: Ctx) Result {
         try self.cmd("quit_without_saving", .{});


### PR DESCRIPTION
nvim binds this by default for hover
dont think you use `w` to quit :upside_down_face: 