### PR TITLE
Replace 'zig-clap' with 'flags'

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -48,7 +48,7 @@ pub fn build(b: *std.Build) void {
     });
     const vaxis_mod = vaxis_dep.module("vaxis");
 
-    const clap_dep = b.dependency("clap", .{
+    const flags_dep = b.dependency("flags", .{
         .target = target,
         .optimize = dependency_optimize,
     });
@@ -225,7 +225,7 @@ pub fn build(b: *std.Build) void {
     if (use_lld_option) |enabled| exe.use_lld = enabled;
 
     exe.root_module.addImport("build_options", options_mod);
-    exe.root_module.addImport("clap", clap_dep.module("clap"));
+    exe.root_module.addImport("flags", flags_dep.module("flags"));
     exe.root_module.addImport("cbor", cbor_mod);
     exe.root_module.addImport("config", config_mod);
     exe.root_module.addImport("tui", tui_mod);
@@ -256,7 +256,7 @@ pub fn build(b: *std.Build) void {
     if (use_lld_option) |enabled| check_exe.use_lld = enabled;
 
     check_exe.root_module.addImport("build_options", options_mod);
-    check_exe.root_module.addImport("clap", clap_dep.module("clap"));
+    check_exe.root_module.addImport("flags", flags_dep.module("flags"));
     check_exe.root_module.addImport("cbor", cbor_mod);
     check_exe.root_module.addImport("config", config_mod);
     check_exe.root_module.addImport("tui", tui_mod);

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,9 +5,9 @@
 
     .dependencies = .{
         .syntax = .{ .path = "src/syntax" },
-        .clap = .{
-            .url = "https://github.com/Hejsil/zig-clap/archive/c0193e9247335a6c1688b946325060289405de2a.tar.gz",
-            .hash = "12207ee987ce045596cb992cfb15b0d6d9456e50d4721c3061c69dabc2962053644d",
+        .flags = .{
+            .url = "https://github.com/n0s4/flags/archive/b3905aa990719ff567f1c5a2f89e6dd3292d8533.tar.gz",
+            .hash = "1220930a42f8da3fb7f723e3ad3f6dcc6db76327dd8d26274566423192d53e91b2bb",
         },
         .tracy = .{
             .url = "https://github.com/neurocyte/zig-tracy/archive/58999b786089e5319dd0707f6afbfca04c6340e7.tar.gz",

--- a/src/main.zig
+++ b/src/main.zig
@@ -137,8 +137,7 @@ pub fn main() anyerror!void {
         exit(1);
     }
 
-    if (args.debug_dump_on_error)
-        thespian.stack_trace_on_errors = true;
+    thespian.stack_trace_on_errors = args.debug_dump_on_error;
 
     var ctx = try thespian.context.init(a);
     defer ctx.deinit();
@@ -185,13 +184,13 @@ pub fn main() anyerror!void {
     log.set_std_log_pid(log_proc.ref());
     defer log.set_std_log_pid(null);
 
-    env.set("restore-session", (args.restore_session));
-    env.set("no-alternate", (args.no_alternate));
-    env.set("show-input", (args.show_input));
-    env.set("show-log", (args.show_log));
-    env.set("no-sleep", (args.no_sleep));
-    env.set("no-syntax", (args.no_syntax));
-    env.set("dump-stack-trace", (args.debug_dump_on_error));
+    env.set("restore-session", args.restore_session);
+    env.set("no-alternate", args.no_alternate);
+    env.set("show-input", args.show_input);
+    env.set("show-log", args.show_log);
+    env.set("no-sleep", args.no_sleep);
+    env.set("no-syntax", args.no_syntax);
+    env.set("dump-stack-trace", args.debug_dump_on_error);
     if (args.frame_rate) |s| env.num_set("frame-rate", @intCast(s));
     env.proc_set("log", log_proc.ref());
     if (args.language) |s| env.str_set("language", s);

--- a/src/main.zig
+++ b/src/main.zig
@@ -66,6 +66,12 @@ pub fn main() anyerror!void {
             .version = "Show build version and exit.",
         };
 
+        pub const formats = .{
+            .frame_rate = "num",
+            .trace_level = "num",
+            .exec = "cmds"
+        };
+
         pub const switches  = .{
             .frame_rate = 'f',
             .trace_level = 't',


### PR DESCRIPTION
This changes the library used for command-line argument parsing from zig-clap to [flags](https://github.com/n0s4/flags/).

Disclaimer: I wrote flags, so I have some personal interest in getting feedback/real world usage.

## Benefits

### Error Messages

Error messages are much more friendly and descriptive:

<details><summary>Old Error Messages (click to view)</summary>
<p>

![image](https://github.com/user-attachments/assets/f1775a69-7640-4362-af15-b647aa44456d)
</p>
</details> 


<details><summary>New Error Messages (click to view)</summary>
<p>

![image](https://github.com/user-attachments/assets/aee32eab-86d7-45ce-9781-57a6b05ea922)
</p>
</details> 

### Help Message

The help message now has a full usage expression, description and terminal colors!

<details><summary>Old Help (click to view)</summary>
<p>

![old-help](https://github.com/user-attachments/assets/aa50ac75-14e8-4d97-8942-2e575e24e281)
</p>
</details> 
<details><summary>New Help (click to view)</summary>
<p>

![new-help](https://github.com/user-attachments/assets/8cc9bea3-c333-4912-be7b-57fffa029de3)
</p>
</details>

Flags also does not use heap allocation.

The actual usage of flags compared to zig-clap is quite similar, but a couple of changes did have to be made:

1. Flags does not (yet) support "repeating flags" which was used to set the trace level by repeating e.g `-tttt`, so instead I made it an integer argument, e.g `-t 4`
2. Flags also doesn't support storing a list of arguments for one flag, so the `--exec` flag which took multiple space-separated commands are now separated by semicolons, e.g `--exec command1;command2`



