### PR TITLE
`enable_format_on_save` now actually saves

### DIFF
--- a/src/tui/editor.zig
+++ b/src/tui/editor.zig
@@ -3169,13 +3169,11 @@ pub const Editor = struct {
 
     pub fn save_file(self: *Self, _: Context) Result {
         if (tui.current().config.enable_format_on_save) if (self.get_formatter()) |_| {
-            self.need_save_after_filter = true;
             const primary = self.get_primary();
             const sel = primary.selection;
             primary.selection = null;
             defer primary.selection = sel;
             try self.format(.{});
-            return;
         };
         try self.save();
     }


### PR DESCRIPTION
The previous previous behavior was extremely frustrating because it meant I had to run `:wq` twice before the program would quit. This was very disruptive to my workflow because I usually use the same terminal pane for both editing code and compiling it so I am quitting and restarting my editor often
