### PR TITLE
win32 gui: remove bespoke/incorrect key translation

### DIFF
--- a/src/keybind/builtin/emacs.json
+++ b/src/keybind/builtin/emacs.json
@@ -2,7 +2,7 @@
     "normal": {
         "press": [
             ["ctrl+g", "cancel"],
-            ["ctrl+shift+-", "undo"],
+            ["ctrl+shift+_", "undo"],
             ["ctrl+k", ["select_end"], ["cut"]],
             ["ctrl+w", "cut"],
 
@@ -14,8 +14,10 @@
             ["alt+f", "move_word_right"],
             ["ctrl+a", "move_begin"],
             ["ctrl+e", "move_end"],
-            ["alt+shift+,", "move_buffer_begin"],
-            ["alt+shift+.", "move_buffer_end"],
+            ["alt+<"        , "move_buffer_begin"],
+            ["alt+shift+<"  , "move_buffer_begin"],
+            ["alt+gt"      , "move_buffer_begin"],
+            ["alt+shift+gt", "move_buffer_end"],
             ["alt+v", "move_page_up"],
             ["ctrl+v", "move_page_down"],
 
@@ -23,7 +25,7 @@
             ["ctrl+d", "delete_forward"],
             ["alt+d", ["select_word_right"], ["cut"]],
             ["ctrl+y", "system_paste"],
-            ["ctrl+x>ctrl+f", "open_recent"],
+            ["ctrl+x>ctrl+f", "open_file"],
             ["ctrl+x>k", "close_file"],
             ["ctrl+x>ctrl+c", "quit"],
             ["ctrl+x>ctrl+s", "save_file"],

--- a/src/keybind/parse_flow.zig
+++ b/src/keybind/parse_flow.zig
@@ -80,5 +80,6 @@ pub const name_map = blk: {
         .{ "escape", input.key.escape },
         .{ "space", input.key.space },
         .{ "backspace", input.key.backspace },
+        .{ "gt", '>' },
     });
 };

--- a/src/keybind/parse_flow.zig
+++ b/src/keybind/parse_flow.zig
@@ -18,7 +18,7 @@ fn parse_error(comptime format: anytype, args: anytype) ParseError {
     return error.InvalidFormat;
 }
 
-pub fn parse_key_events(allocator: std.mem.Allocator, event: input.Event, str: []const u8) ParseError![]input.KeyEvent {
+pub fn parse_key_events(allocator: std.mem.Allocator, str: []const u8) ParseError![]input.KeyEvent {
     parse_error_reset();
     if (str.len == 0) return parse_error("empty", .{});
     var result_events = std.ArrayList(input.KeyEvent).init(allocator);
@@ -65,7 +65,7 @@ pub fn parse_key_events(allocator: std.mem.Allocator, event: input.Event, str: [
             if (key == null) return parse_error("unknown key '{s}' in '{s}'", .{ part, str });
         }
         if (key) |k|
-            try result_events.append(.{ .event = event, .key = k, .modifiers = @bitCast(mods) })
+            try result_events.append(input.KeyEvent.from_key_modset(k, mods))
         else
             return parse_error("no key defined in '{s}'", .{str});
     }

--- a/src/tui/inputview.zig
+++ b/src/tui/inputview.zig
@@ -110,29 +110,18 @@ pub fn listen(self: *Self, _: tp.pid_ref, m: tp.message) tp.result {
 
     var event: input.Event = 0;
     var keypress: input.Key = 0;
-    var egc: input.Key = 0;
+    var keypress_shifted: input.Key = 0;
     var text: []const u8 = "";
     var modifiers: input.Mods = 0;
     if (try m.match(.{
         "I",
         tp.extract(&event),
         tp.extract(&keypress),
-        tp.extract(&egc),
+        tp.extract(&keypress_shifted),
         tp.extract(&text),
         tp.extract(&modifiers),
     })) {
-        var key_event: input.KeyEvent = .{
-            .event = event,
-            .key = keypress,
-            .modifiers = modifiers,
-        };
-        key_event.modifiers = switch (key_event.key) {
-            input.key.left_super, input.key.right_super => key_event.modifiers & ~input.mod.super,
-            input.key.left_shift, input.key.right_shift => key_event.modifiers & ~input.mod.shift,
-            input.key.left_control, input.key.right_control => key_event.modifiers & ~input.mod.ctrl,
-            input.key.left_alt, input.key.right_alt => key_event.modifiers & ~input.mod.alt,
-            else => key_event.modifiers,
-        };
+        const key_event = input.KeyEvent.from_message(event, keypress, keypress_shifted, text, modifiers);
         writer.print(" -> {}", .{key_event}) catch |e| return tp.exit_error(e, @errorReturnTrace());
     }
     self.append(result.items) catch |e| return tp.exit_error(e, @errorReturnTrace());

--- a/src/win32/gui.zig
+++ b/src/win32/gui.zig
@@ -792,8 +792,9 @@ fn sendKey(
     }
     for (char_buf[0..@intCast(unicode_result)]) |codepoint| {
         const mod_bits = @as(u8, @bitCast(mods));
+        const is_modified = mod_bits & ~(input.mod.shift | input.mod.caps_lock) != 0; // ignore shift and caps
         var utf8_buf: [6]u8 = undefined;
-        const utf8_len = if (event == input.event.press and (mod_bits & 0xBE == 0)) // ignore shift and caps
+        const utf8_len = if (event == input.event.press and !is_modified)
             std.unicode.utf8Encode(codepoint, &utf8_buf) catch {
                 std.log.err("invalid codepoint {}", .{codepoint});
                 continue;


### PR DESCRIPTION
I played around with the API a bit and I tried out the other approach where instead of trying to implement our own keyboard translation, instead I just clear the "control key" before calling ToUnicode.  This fixes any weird translation the OS was doing.

With this change, we no longer need to skip calling ToUnicode if the control or alt keys are down, so keys will always work the same way whether or not these modifiers are down.


P.S. this seems to bring the win32 GUI inline with the WindowsTerminal in how it handles input.   For example, pressing `alt+shift+.` (where `.` is the `.>` key on my keyboard) will produce the `>` character in both Windows Terminal and the GUI now.