### PR TITLE
win32 gui: track and use window bounds to prevent infinite shrinkage

### DIFF
--- a/src/keybind/builtin/emacs.json
+++ b/src/keybind/builtin/emacs.json
@@ -1,4 +1,10 @@
 {
+    "project": {
+        "press": [
+            ["ctrl+=", "adjust_fontsize", 1.0],
+            ["ctrl+-", "adjust_fontsize", -1.0]
+        ]
+    },
     "normal": {
         "press": [
             ["ctrl+g", "cancel"],


### PR DESCRIPTION
# Before

https://github.com/user-attachments/assets/f45089e3-206d-4599-a700-7891f2f48aa4


# After  

https://github.com/user-attachments/assets/5355ce63-8188-4d8a-92c0-7fe1ce500405

