### PR TITLE
Helix mode half and whole page movements

### DIFF
--- a/src/buffer/Cursor.zig
+++ b/src/buffer/Cursor.zig
@@ -103,6 +103,24 @@ pub fn move_page_down(self: *Self, root: Buffer.Root, view: *const View, metrics
     self.move_right_no_target(root, metrics) catch return;
 }
 
+pub fn move_half_page_up(self: *Self, root: Buffer.Root, view: *const View, metrics: Metrics) void {
+    const half_view_rows = @divTrunc(view.rows, 2);
+    self.row = if (self.row > half_view_rows) self.row - half_view_rows else 0;
+    self.follow_target(root, metrics);
+    self.move_left_no_target(root, metrics) catch return;
+    self.move_right_no_target(root, metrics) catch return;
+}
+
+pub fn move_half_page_down(self: *Self, root: Buffer.Root, view: *const View, metrics: Metrics) void {
+    const half_view_rows = @divTrunc(view.rows, 2);
+    if (root.lines() > self.row + half_view_rows) {
+        self.row += half_view_rows;
+    } else self.move_buffer_last(root, metrics);
+    self.follow_target(root, metrics);
+    self.move_left_no_target(root, metrics) catch return;
+    self.move_right_no_target(root, metrics) catch return;
+}
+
 pub fn move_to(self: *Self, root: Buffer.Root, row: usize, col: usize, metrics: Metrics) !void {
     if (row < root.lines()) {
         self.row = row;

--- a/src/keybind/builtin/helix.json
+++ b/src/keybind/builtin/helix.json
@@ -11,8 +11,8 @@
         "press": [
             ["ctrl+b", "move_scroll_page_up"],
             ["ctrl+f", "move_scroll_page_down"],
-            ["ctrl+u", "page_cursor_half_up"],
-            ["ctrl+d", "page_cursor_half_down"],
+            ["ctrl+u", "move_scroll_half_page_up"],
+            ["ctrl+d", "move_scroll_half_page_down"],
             ["ctrl+c", "toggle_comment"],
             ["ctrl+i", "jump_forward"],
             ["ctrl+o", "jump_back"],
@@ -253,10 +253,10 @@
         "line_numbers": "relative",
         "cursor": "block",
         "press": [
-            ["ctrl+b", "move_scroll_page_up"],
-            ["ctrl+f", "move_scroll_page_down"],
-            ["ctrl+u", "page_cursor_half_up"],
-            ["ctrl+d", "page_cursor_half_down"],
+            ["ctrl+b", "select_page_up"],
+            ["ctrl+f", "select_page_down"],
+            ["ctrl+u", "select_half_page_up"],
+            ["ctrl+d", "select_half_page_down"],
 
             ["ctrl+c", "toggle_comment"],
 


### PR DESCRIPTION
I've added half page movements and changed the command for page up/down in select mode.

It's not an one-to-one replica of helix's movements, there's a few minor differences such as clamping and how page up&down is calculated. If fidelity is a must I'll make the necessary changes, just let me know.