### PR TITLE
swap enable_fast_scroll and enable_jump_mode keybinds

### DIFF
--- a/src/keybind/builtin/flow.json
+++ b/src/keybind/builtin/flow.json
@@ -152,10 +152,10 @@
             ["page_up", "move_page_up"],
             ["page_down", "move_page_down"],
             ["tab", "indent"],
-            ["left_control", "enable_fast_scroll"],
-            ["right_control", "enable_fast_scroll"],
-            ["left_alt", "enable_jump_mode"],
-            ["right_alt", "enable_jump_mode"],
+            ["left_alt", "enable_fast_scroll"],
+            ["right_alt", "enable_fast_scroll"],
+            ["left_control", "enable_jump_mode"],
+            ["right_control", "enable_jump_mode"],
             ["ctrl+space", "enter_mode", "select"]
         ],
         "release": [


### PR DESCRIPTION
after looking into addressing the part of #141 actively bothering me, I found out that the modifiers for the mouse commands aren't queried directly, rather by which mode is currently active. This change swaps the `fast_scroll` and `jump_mode` keybinds, which in turn makes the `goto_definition` and `add_cursor` mouse actions behave like VSCode. This might already be enough to close the issue, since I don't know of other editors that allow mouse behavior rebinding.