### PR TITLE
win32 gui: add Fonts type to get list of available fonts

### DIFF
--- a/src/win32/DwriteRenderer.zig
+++ b/src/win32/DwriteRenderer.zig
@@ -8,6 +8,7 @@ const dwrite = @import("dwrite.zig");
 const XY = @import("xy.zig").XY;
 
 pub const Font = dwrite.Font;
+pub const Fonts = dwrite.Fonts;
 
 pub const needs_direct2d = true;
 

--- a/src/win32/d3d11.zig
+++ b/src/win32/d3d11.zig
@@ -10,6 +10,7 @@ const TextRenderer = @import("DwriteRenderer.zig");
 const XY = @import("xy.zig").XY;
 
 pub const Font = TextRenderer.Font;
+pub const Fonts = TextRenderer.Fonts;
 
 const log = std.log.scoped(.d3d);
 


### PR DESCRIPTION
Adds a Fonts type the render interface.  Here's an example of how you could use this in `gui.zig`:

```zig
    const fonts = render.Fonts.init();
    defer fonts.deinit();
    const count = fonts.count();
    std.log.info("{} fonts", .{count});
    for (0..count) |font_index| {
        const name = fonts.getName(font_index);
        std.log.info("font {} '{}'", .{ font_index, std.unicode.fmtUtf16Le(name.slice()) });
    }
```