### PR TITLE
add systemverilog lsp and formatter

### DIFF
--- a/src/syntax/build.zig
+++ b/src/syntax/build.zig
@@ -76,6 +76,7 @@ pub fn build(b: *std.Build) void {
         ts_queryfile(b, tree_sitter_dep, "tree-sitter-zig/queries/highlights.scm"),
         ts_queryfile(b, tree_sitter_dep, "tree-sitter-ziggy/tree-sitter-ziggy/queries/highlights.scm"),
         ts_queryfile(b, tree_sitter_dep, "tree-sitter-ziggy/tree-sitter-ziggy-schema/queries/highlights.scm"),
+        ts_queryfile(b, tree_sitter_dep, "nvim-treesitter/queries/verilog/highlights.scm"),
 
         ts_queryfile(b, tree_sitter_dep, "queries/cmake/injections.scm"),
         ts_queryfile(b, tree_sitter_dep, "tree-sitter-cpp/queries/injections.scm"),
@@ -102,6 +103,7 @@ pub fn build(b: *std.Build) void {
         ts_queryfile(b, tree_sitter_dep, "tree-sitter-typst/queries/typst/injections.scm"),
         ts_queryfile(b, tree_sitter_dep, "tree-sitter-vim/queries/vim/injections.scm"),
         ts_queryfile(b, tree_sitter_dep, "tree-sitter-zig/queries/injections.scm"),
+        ts_queryfile(b, tree_sitter_dep, "nvim-treesitter/queries/verilog/injections.scm"),
     } else &.{
         .{ .name = "build_options", .module = options_mod },
     };

--- a/src/syntax/build.zig.zon
+++ b/src/syntax/build.zig.zon
@@ -4,8 +4,8 @@
 
     .dependencies = .{
         .@"tree-sitter" = .{
-            .url = "https://github.com/neurocyte/tree-sitter/releases/download/master-aea6072c6178d5cd0c97fff33e130f632f355bc2/source.tar.gz",
-            .hash = "12204c99c6093230023380068f386f7eb32ab83df9a8eb8b586ffe5aa44afa34ff0e",
+            .url = "https://github.com/neurocyte/tree-sitter/releases/download/master-f7a38f045f20164d333e355ac1a9d31d8352502b/source.tar.gz",
+            .hash = "122097835c8367b58cb57f55d6d60d12d93be0926e68544a1de996e883b53b82df44",
         },
     },
     .paths = .{

--- a/src/syntax/src/file_types.zig
+++ b/src/syntax/src/file_types.zig
@@ -450,6 +450,16 @@ pub const swift = .{
     .formatter = .{"swift-format"},
 };
 
+pub const verilog = .{
+    .description = "SystemVerilog",
+    .extensions = .{ "sv", "svh" },
+    .comment = "//",
+    .highlights = "nvim-treesitter/queries/verilog/highlights.scm",
+    .injections = "nvim-treesitter/queries/verilog/injections.scm",
+    .language_server = .{"verible-verilog-ls"},
+    .formatter = .{ "verible-verilog-format", "-" }
+};
+
 pub const toml = .{
     .description = "TOML",
     .extensions = .{ "toml", "ini" },


### PR DESCRIPTION
This depends on https://github.com/neurocyte/tree-sitter/pull/8. Marked as draft because the `tree-sitter` dep url and hash will need to be updated before this builds.

![image](https://github.com/user-attachments/assets/49fc00a8-8814-42d3-b8e3-e659031c0c27)