### PR TITLE
Develop `helix_mode` internals and basic commands

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -370,6 +370,7 @@ pub fn build_exe(
             .{ .name = "input", .module = input_mod },
             .{ .name = "thespian", .module = thespian_mod },
             .{ .name = "log", .module = log_mod },
+            .{ .name = "Buffer", .module = Buffer_mod },
         },
     });
 

--- a/src/buffer/Selection.zig
+++ b/src/buffer/Selection.zig
@@ -6,6 +6,8 @@ end: Cursor = Cursor{},
 
 const Self = @This();
 
+pub const Style = enum { normal, inclusive };
+
 pub inline fn eql(self: Self, other: Self) bool {
     return self.begin.eql(other.begin) and self.end.eql(other.end);
 }

--- a/src/buffer/Selection.zig
+++ b/src/buffer/Selection.zig
@@ -33,7 +33,7 @@ pub fn reverse(self: *Self) void {
     self.end = tmp;
 }
 
-pub inline fn is_reversed(self: *Self) bool {
+pub inline fn is_reversed(self: *const Self) bool {
     return self.begin.right_of(self.end);
 }
 

--- a/src/keybind/builtin/helix.json
+++ b/src/keybind/builtin/helix.json
@@ -8,6 +8,7 @@
         "name": "NOR",
         "line_numbers": "relative",
         "cursor": "block",
+        "selection": "inclusive",
         "press": [
             ["ctrl+b", "move_scroll_page_up"],
             ["ctrl+f", "move_scroll_page_down"],
@@ -252,6 +253,7 @@
         "name": "SEL",
         "line_numbers": "relative",
         "cursor": "block",
+        "selection": "inclusive",
         "press": [
             ["ctrl+b", "select_page_up"],
             ["ctrl+f", "select_page_down"],

--- a/src/tui/editor.zig
+++ b/src/tui/editor.zig
@@ -106,6 +106,16 @@ pub const CurSel = struct {
         };
     }
 
+    fn enable_selection_helix(self: *Self, root: Buffer.Root, metrics: Buffer.Metrics) *Selection {
+        return if (self.selection) |*sel|
+            sel
+        else cod: {
+            self.selection = Selection.from_cursor(&self.cursor);
+            try self.selection.?.end.move_right(root, metrics);
+            break :cod &self.selection.?;
+        };
+    }
+
     fn check_selection(self: *Self) void {
         if (self.selection) |sel| if (sel.empty()) {
             self.selection = null;

--- a/src/tui/tui.zig
+++ b/src/tui/tui.zig
@@ -951,13 +951,11 @@ const cmds = struct {
 
     pub fn enter_helix_mode(_: *Self, _: Ctx) Result {
         try @import("mode/helix.zig").init();
-        if (get_active_editor()) |editor| editor.enable_helix_selection = true;
     }
     pub const enter_helix_mode_meta = .{};
 
     pub fn exit_helix_mode(_: *Self, _: Ctx) Result {
         @import("mode/helix.zig").deinit();
-        if (get_active_editor()) |editor| editor.enable_helix_selection = false;
     }
     pub const exit_helix_mode_meta = .{};
 };
@@ -1173,4 +1171,8 @@ pub fn is_cursor_beam(self: *Self) bool {
         .beam, .beam_blink => true,
         else => false,
     };
+}
+
+pub fn get_selection_style(self: *Self) @import("Buffer").Selection.Style {
+    return if (self.input_mode) |mode| mode.selection_style else .normal;
 }

--- a/src/tui/tui.zig
+++ b/src/tui/tui.zig
@@ -951,11 +951,13 @@ const cmds = struct {
 
     pub fn enter_helix_mode(_: *Self, _: Ctx) Result {
         try @import("mode/helix.zig").init();
+        if (get_active_editor()) |editor| editor.enable_helix_selection = true;
     }
     pub const enter_helix_mode_meta = .{};
 
     pub fn exit_helix_mode(_: *Self, _: Ctx) Result {
         @import("mode/helix.zig").deinit();
+        if (get_active_editor()) |editor| editor.enable_helix_selection = false;
     }
     pub const exit_helix_mode_meta = .{};
 };


### PR DESCRIPTION
Here's my take on how to tweak tui/editor.zig to get cursors and selections playing nice with helix mode.

Still have to add commands like moving left and right to mimic the behavior in helix, especially when text is selected and we're moving out of that.