### PR TITLE
win32 gui: fix high cpu usage, validate window in WM_PAINT

### DIFF
--- a/src/win32/gui.zig
+++ b/src/win32/gui.zig
@@ -1040,6 +1040,10 @@ fn WndProc(
             const font = getFont(dpi, getFontSize(), getFontFace());
             const client_size = getClientSize(u32, hwnd);
 
+            var ps: win32.PAINTSTRUCT = undefined;
+            _ = win32.BeginPaint(hwnd, &ps) orelse return fatalWin32("BeginPaint", win32.GetLastError());
+            defer if (0 == win32.EndPaint(hwnd, &ps)) fatalWin32("EndPaint", win32.GetLastError());
+
             global.render_cells.resize(
                 global.render_cells_arena.allocator(),
                 global.screen.buf.len,


### PR DESCRIPTION
Looks like I probably accidently removed the calls to BeginPaint and EndPaint in WM_PAINT, which, would cause the OS to think that the window contents are never validated and will continuously send us WM_PAINT messages.  I've added these back in and now flow is back to low CPU usage especially when idle.