### PR TITLE
remove direct2d dependency and update zigwin32

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -318,16 +318,13 @@ pub fn build_exe(
     const renderer_mod = blk: {
         if (gui) switch (target.result.os.tag) {
             .windows => {
-                const direct2d_dep = b.lazyDependency("direct2d", .{}) orelse break :blk tui_renderer_mod;
-
-                const win32_dep = direct2d_dep.builder.dependency("win32", .{});
-                const win32_mod = win32_dep.module("zigwin32");
+                const win32_dep = b.lazyDependency("win32", .{}) orelse break :blk tui_renderer_mod;
+                const win32_mod = win32_dep.module("win32");
                 const gui_mod = b.createModule(.{
                     .root_source_file = b.path("src/win32/gui.zig"),
                     .imports = &.{
                         .{ .name = "build_options", .module = options_mod },
                         .{ .name = "win32", .module = win32_mod },
-                        .{ .name = "ddui", .module = direct2d_dep.module("ddui") },
                         .{ .name = "cbor", .module = cbor_mod },
                         .{ .name = "thespian", .module = thespian_mod },
                         .{ .name = "input", .module = input_mod },

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -37,9 +37,9 @@
             .url = "https://github.com/rockorager/zeit/archive/9cca8ec620a54c3b07cd249f25e5bcb3153d03d7.tar.gz",
             .hash = "1220755ea2a5aa6bb3713437aaafefd44812169fe43f1da755c3ee6101b85940f441",
         },
-        .direct2d = .{
-            .url = "https://github.com/marler8997/direct2d-zig/archive/0d031389a26653bb71f81c2340d1b8ba6bd339c3.tar.gz",
-            .hash = "122069b40656962c6ba9b9b3f9f882ba2e9cf4c5e1afebac7b7501404129e6bb4705",
+        .win32 = .{
+            .url = "https://github.com/marlersoft/zigwin32/archive/259b6f353a48968d7e3171573db4fd898b046188.tar.gz",
+            .hash = "1220925614447b54ccc9894bbba8b202c6a8b750267890edab7732064867e46f3217",
             .lazy = true,
         },
     },

--- a/src/win32/win32ext.zig
+++ b/src/win32/win32ext.zig
@@ -1,17 +1,6 @@
 const std = @import("std");
 const win32 = @import("win32").everything;
 
-// todo: these should be available in zigwin32
-fn xFromLparam(lparam: win32.LPARAM) i16 {
-    return @bitCast(win32.loword(lparam));
-}
-fn yFromLparam(lparam: win32.LPARAM) i16 {
-    return @bitCast(win32.hiword(lparam));
-}
-pub fn pointFromLparam(lparam: win32.LPARAM) win32.POINT {
-    return win32.POINT{ .x = xFromLparam(lparam), .y = yFromLparam(lparam) };
-}
-
 // TODO: update zigwin32 with a way to get the corresponding IID for any COM interface
 pub fn queryInterface(obj: anytype, comptime Interface: type) *Interface {
     const obj_basename_start: usize = comptime if (std.mem.lastIndexOfScalar(u8, @typeName(@TypeOf(obj)), '.')) |i| (i + 1) else 0;


### PR DESCRIPTION
Since we removed the direct2d renderer we no longer need to reference the direct2d-zig repository.  Instead we now directly reference the zigwin32 repository.  I've also updated that repository with a few fixes and additions which allowed us to remove some code from flow.