### PR TITLE
use @returnAddress in panic handler

### DIFF
--- a/src/renderer/vaxis/renderer.zig
+++ b/src/renderer/vaxis/renderer.zig
@@ -86,7 +86,7 @@ pub fn panic(msg: []const u8, error_return_trace: ?*std.builtin.StackTrace, ret_
         self.vx.deinit(self.allocator, self.tty.anyWriter());
         self.tty.deinit();
     }
-    return std.builtin.default_panic(msg, error_return_trace, ret_addr);
+    return std.builtin.default_panic(msg, error_return_trace, ret_addr orelse @returnAddress());
 }
 
 pub fn run(self: *Self) !void {


### PR DESCRIPTION
the current code causes the call to panic itself to show up in the stack trace which is noisy
before:
```
thread 17618 panic: oopsies
/home/jonah/dev/flow/src/renderer/vaxis/renderer.zig:90:37: 0x107cd06 in panic (flow)
    return std.builtin.default_panic(msg, error_return_trace, ret_addr);
                                    ^
/home/jonah/dev/flow/src/main.zig:38:15: 0x107d0e0 in main (flow)
    if (true) @panic("oopsies");
              ^
/home/jonah/dev/ghostty/zig-linux-x86_64-0.13.0/lib/std/start.zig:524:37: 0x107cba7 in main (flow)
            const result = root.main() catch |err| {
                                    ^
```
after:
```
thread 18109 panic: oopsies
/home/jonah/dev/flow/src/main.zig:38:15: 0x107d140 in main (flow)
    if (true) @panic("oopsies");
              ^
/home/jonah/dev/ghostty/zig-linux-x86_64-0.13.0/lib/std/start.zig:524:37: 0x107cba7 in main (flow)
            const result = root.main() catch |err| {
                                    ^
```