### PR TITLE
Remove 'jk' keybinding in Vim's INSERT mode

### DIFF
--- a/src/keybind/builtin/vim.json
+++ b/src/keybind/builtin/vim.json
@@ -102,7 +102,6 @@
         "line_numbers": "absolute",
         "cursor": "beam",
         "press": [
-            ["jk", "enter_mode", "normal"],
             ["<Esc>", "enter_mode", "normal"],
             ["<Del>", "delete_forward"],
             ["<BS>", "delete_backward"],


### PR DESCRIPTION
Currently, pressing `j` while in INSERT mode in the Vim input mode waits for another key to be pressed. Pressing any key after pressing `j` would write `j<whatever key was pressed>`, and pressing `k` after `j` would exit INSERT mode.

This fixes that by removing the `jk` keybinding from `vim.json`, as it is entirely unnecessary, and is not like this at all in the actual Vim.