### PR TITLE
More vim bindings, visual line mode, QOL vim things

### DIFF
--- a/src/keybind/builtin/vim.json
+++ b/src/keybind/builtin/vim.json
@@ -20,8 +20,8 @@
             ["s", ["cut_forward_internal"], ["enter_mode", "insert"]],
             ["u", "undo"],
 
-            ["j", "move_down"],
-            ["k", "move_up"],
+            ["j", "move_down_vim"],
+            ["k", "move_up_vim"],
             ["l", "move_right_vim"],
             ["h", "move_left_vim"],
             ["<Space>", "move_right_vim"],
@@ -33,15 +33,20 @@
             ["o", ["smart_insert_line_after"], ["enter_mode", "insert"]],
             ["O", ["smart_insert_line_before"], ["enter_mode", "insert"]],
 
+            ["<S-.><S-.>", "indent"],
+            ["<S-,><S-,>", "unindent"],
+
             ["v", "enter_mode", "visual"],
-            ["V", ["move_begin"], ["enter_mode", "visual"], ["select_end"]],
+            ["V", ["enter_mode", "visual line"], ["select_line_vim"]],
 
             ["n", "goto_next_match"],
             ["0", "move_begin"],
             ["^", "smart_move_begin"],
             ["$", "move_end"],
             [":", "open_command_palette"],
+
             ["p", "paste_internal_vim"],
+            ["P", "paste_internal_vim"],
 
             ["gd", "goto_definition"],
             ["gi", "goto_implementation"],
@@ -59,8 +64,11 @@
 
             ["yy", ["copy_line_internal_vim"], ["cancel"]],
 
-            ["<C-u>", "move_scroll_page_up"],
-            ["<C-d>", "move_scroll_page_down"],
+            ["<C-u>", "move_scroll_half_page_up_vim"],
+            ["<C-d>", "move_scroll_half_page_down_vim"],
+
+            ["zz", "scroll_view_center"],
+
             ["u", "undo"],
             ["<C-r>", "redo"],
             ["<C-o>", "jump_back"],
@@ -83,17 +91,63 @@
         "cursor": "block",
         "selection": "normal",
         "press": [
-            ["<Esc>", "enter_mode", "normal"],
+            ["<Esc>", ["cancel"], ["enter_mode", "normal"]],
             ["k", "select_up"],
             ["j", "select_down"],
             ["h", "select_left"],
             ["l", "select_right"],
+
+            ["0", "move_begin"],
+            ["^", "smart_move_begin"],
+            ["$", "move_end"],
+
+            ["p", ["paste_internal_vim"], ["enter_mode", "normal"]],
+            ["P", ["paste_internal_vim"], ["enter_mode", "normal"]],
+
+            ["<C-u>", "move_scroll_half_page_up_vim"],
+            ["<C-d>", "move_scroll_half_page_down_vim"],
+
+            ["zz", "scroll_view_center"],
+            ["<S-.>", "indent"],
+            ["<S-,>", "unindent"],
 
             ["y", ["copy_internal_vim"], ["cancel"], ["enter_mode", "normal"]],
 
             ["x", ["cut_forward_internal"], ["cancel"], ["enter_mode", "normal"]],
             ["d", ["cut_forward_internal"], ["cancel"], ["enter_mode", "normal"]],
             ["s", ["cut_forward_internal"], ["cancel"], ["enter_mode", "insert"]]
+        ]
+    },
+    "visual line": {
+        "syntax": "vim",
+        "on_match_failure": "ignore",
+        "name": "VISUAL LINE",
+        "line_numbers": "relative",
+        "cursor": "block",
+        "selection": "normal",
+        "press": [
+            ["<Esc>", ["cancel"], ["enter_mode", "normal"]],
+            ["k", "select_up"],
+            ["j", "select_down"],
+
+            ["0", "move_begin"],
+            ["^", "smart_move_begin"],
+            ["$", "move_end"],
+
+            ["p", ["paste_internal_vim"], ["enter_mode", "normal"]],
+            ["P", ["paste_internal_vim"], ["enter_mode", "normal"]],
+
+            ["<C-u>", "move_scroll_half_page_up_vim"],
+            ["<C-d>", "move_scroll_half_page_down_vim"],
+
+            ["<S-.>", "indent"],
+            ["<S-,>", "unindent"],
+
+            ["y", ["copy_line_internal_vim"], ["cancel"], ["enter_mode", "normal"]],
+
+            ["x", ["cut_internal_vim"], ["cancel"], ["enter_mode", "normal"]],
+            ["d", ["cut_internal_vim"], ["cancel"], ["enter_mode", "normal"]],
+            ["s", ["cut_internal_vim"], ["cancel"], ["enter_mode", "insert"]]
         ]
     },
     "insert": {
@@ -103,7 +157,7 @@
         "cursor": "beam",
         "press": [
             ["jk", "enter_mode", "normal"],
-            ["<Esc>", "enter_mode", "normal"],
+            ["<Esc>", ["move_left_vim"], ["enter_mode", "normal"]],
             ["<Del>", "delete_forward"],
             ["<BS>", "delete_backward"],
             ["<CR>", "smart_insert_line"],

--- a/src/keybind/builtin/vim.json
+++ b/src/keybind/builtin/vim.json
@@ -176,7 +176,6 @@
         "line_numbers": "absolute",
         "cursor": "beam",
         "press": [
-            ["jk", "enter_mode", "normal"],
             ["<Esc>", ["move_left_vim"], ["enter_mode", "normal"]],
             ["<Del>", "delete_forward"],
             ["<BS>", "delete_backward"],

--- a/src/keybind/builtin/vim.json
+++ b/src/keybind/builtin/vim.json
@@ -62,6 +62,12 @@
             ["dd", "cut_internal_vim"],
             ["\"_dd", "delete_line"],
 
+            ["cc", ["delete_line"], ["enter_mode", "insert"]],
+            ["C", ["delete_to_end"], ["enter_mode", "insert"]],
+            ["D", "delete_to_end"],
+            ["cw", ["cut_word_right_vim"], ["enter_mode", "insert"]],
+            ["cb", ["cut_word_left_vim"], ["enter_mode", "insert"]],
+
             ["yy", ["copy_line_internal_vim"], ["cancel"]],
 
             ["<C-u>", "move_scroll_half_page_up_vim"],
@@ -115,7 +121,11 @@
 
             ["x", ["cut_forward_internal"], ["cancel"], ["enter_mode", "normal"]],
             ["d", ["cut_forward_internal"], ["cancel"], ["enter_mode", "normal"]],
-            ["s", ["cut_forward_internal"], ["cancel"], ["enter_mode", "insert"]]
+            ["s", ["cut_forward_internal"], ["cancel"], ["enter_mode", "insert"]],
+
+            ["c", ["cut_forward_internal"], ["cancel"], ["enter_mode", "insert"]],
+            ["C", ["delete_to_end"], ["enter_mode", "insert"]],
+            ["D", "delete_to_end"]
         ]
     },
     "visual line": {
@@ -147,7 +157,11 @@
 
             ["x", ["cut_internal_vim"], ["cancel"], ["enter_mode", "normal"]],
             ["d", ["cut_internal_vim"], ["cancel"], ["enter_mode", "normal"]],
-            ["s", ["cut_internal_vim"], ["cancel"], ["enter_mode", "insert"]]
+            ["s", ["cut_internal_vim"], ["cancel"], ["enter_mode", "insert"]],
+
+            ["c", ["cut_forward_internal"], ["cancel"], ["enter_mode", "insert"]],
+            ["C", ["delete_to_end"], ["enter_mode", "insert"]],
+            ["D", "delete_to_end"]
         ]
     },
     "insert": {

--- a/src/keybind/builtin/vim.json
+++ b/src/keybind/builtin/vim.json
@@ -62,7 +62,7 @@
             ["dd", "cut_internal_vim"],
             ["\"_dd", "delete_line"],
 
-            ["cc", ["delete_line"], ["enter_mode", "insert"]],
+            ["cc", ["cut_internal_vim"], ["enter_mode", "insert"]],
             ["C", ["delete_to_end"], ["enter_mode", "insert"]],
             ["D", "delete_to_end"],
             ["cw", ["cut_word_right_vim"], ["enter_mode", "insert"]],

--- a/src/keybind/builtin/vim.json
+++ b/src/keybind/builtin/vim.json
@@ -56,15 +56,15 @@
             ["gD", "goto_declaration"],
             ["G", "move_buffer_end"],
 
-            ["d$", "delete_to_end"],
+            ["d$", "cut_to_end_vim"],
             ["dw", "cut_word_right_vim"],
             ["db", "cut_word_left_vim"],
             ["dd", "cut_internal_vim"],
             ["\"_dd", "delete_line"],
 
             ["cc", ["cut_internal_vim"], ["enter_mode", "insert"]],
-            ["C", ["delete_to_end"], ["enter_mode", "insert"]],
-            ["D", "delete_to_end"],
+            ["C", ["cut_to_end_vim"], ["enter_mode", "insert"]],
+            ["D", "cut_to_end_vim"],
             ["cw", ["cut_word_right_vim"], ["enter_mode", "insert"]],
             ["cb", ["cut_word_left_vim"], ["enter_mode", "insert"]],
 
@@ -103,6 +103,12 @@
             ["h", "select_left"],
             ["l", "select_right"],
 
+            ["b", "select_word_left_vim"],
+            ["w", "select_word_right_vim"],
+            ["W", "select_word_right"],
+            ["B", "select_word_left"],
+            ["e", "select_word_right_end_vim"],
+
             ["0", "move_begin"],
             ["^", "smart_move_begin"],
             ["$", "move_end"],
@@ -124,8 +130,8 @@
             ["s", ["cut_forward_internal"], ["cancel"], ["enter_mode", "insert"]],
 
             ["c", ["cut_forward_internal"], ["cancel"], ["enter_mode", "insert"]],
-            ["C", ["delete_to_end"], ["enter_mode", "insert"]],
-            ["D", "delete_to_end"]
+            ["C", ["cut_to_end_vim"], ["enter_mode", "insert"]],
+            ["D", "cut_to_end_vim"]
         ]
     },
     "visual line": {
@@ -160,8 +166,8 @@
             ["s", ["cut_internal_vim"], ["cancel"], ["enter_mode", "insert"]],
 
             ["c", ["cut_forward_internal"], ["cancel"], ["enter_mode", "insert"]],
-            ["C", ["delete_to_end"], ["enter_mode", "insert"]],
-            ["D", "delete_to_end"]
+            ["C", ["cut_to_end_vim"], ["enter_mode", "insert"]],
+            ["D", "cut_to_end_vim"]
         ]
     },
     "insert": {
@@ -170,8 +176,8 @@
         "line_numbers": "absolute",
         "cursor": "beam",
         "press": [
-
-            ["<Esc>", "enter_mode", "normal"],
+            ["jk", "enter_mode", "normal"],
+            ["<Esc>", ["move_left_vim"], ["enter_mode", "normal"]],
             ["<Del>", "delete_forward"],
             ["<BS>", "delete_backward"],
             ["<CR>", "smart_insert_line"],

--- a/src/keybind/builtin/vim.json
+++ b/src/keybind/builtin/vim.json
@@ -125,11 +125,11 @@
 
             ["y", ["copy_internal_vim"], ["cancel"], ["enter_mode", "normal"]],
 
-            ["x", ["cut_forward_internal"], ["cancel"], ["enter_mode", "normal"]],
-            ["d", ["cut_forward_internal"], ["cancel"], ["enter_mode", "normal"]],
-            ["s", ["cut_forward_internal"], ["cancel"], ["enter_mode", "insert"]],
+            ["x", ["cut_forward_internal"], ["enter_mode", "normal"]],
+            ["d", ["cut_forward_internal"], ["enter_mode", "normal"]],
+            ["s", ["cut_forward_internal"], ["enter_mode", "insert"]],
 
-            ["c", ["cut_forward_internal"], ["cancel"], ["enter_mode", "insert"]],
+            ["c", ["cut_forward_internal"], ["enter_mode", "insert"]],
             ["C", ["cut_to_end_vim"], ["enter_mode", "insert"]],
             ["D", "cut_to_end_vim"]
         ]
@@ -161,11 +161,11 @@
 
             ["y", ["copy_line_internal_vim"], ["cancel"], ["enter_mode", "normal"]],
 
-            ["x", ["cut_internal_vim"], ["cancel"], ["enter_mode", "normal"]],
-            ["d", ["cut_internal_vim"], ["cancel"], ["enter_mode", "normal"]],
-            ["s", ["cut_internal_vim"], ["cancel"], ["enter_mode", "insert"]],
+            ["x", ["cut_internal_vim"], ["enter_mode", "normal"]],
+            ["d", ["cut_internal_vim"], ["enter_mode", "normal"]],
+            ["s", ["cut_internal_vim"], ["enter_mode", "insert"]],
 
-            ["c", ["cut_forward_internal"], ["cancel"], ["enter_mode", "insert"]],
+            ["c", ["cut_internal_vim"], ["enter_mode", "insert"]],
             ["C", ["cut_to_end_vim"], ["enter_mode", "insert"]],
             ["D", "cut_to_end_vim"]
         ]

--- a/src/tui/editor.zig
+++ b/src/tui/editor.zig
@@ -2088,6 +2088,10 @@ pub const Editor = struct {
         cursor.move_end(root, metrics);
     }
 
+    fn move_cursor_end_vim(root: Buffer.Root, cursor: *Cursor, metrics: Buffer.Metrics) !void {
+        move_cursor_right_until(root, cursor, is_eol_vim, metrics);
+    }
+
     fn move_cursor_up(root: Buffer.Root, cursor: *Cursor, metrics: Buffer.Metrics) !void {
         try cursor.move_up(root, metrics);
     }
@@ -2775,6 +2779,15 @@ pub const Editor = struct {
         self.clamp();
     }
     pub const delete_to_end_meta = .{ .description = "Delete to end of line" };
+
+    pub fn cut_to_end_vim(self: *Self, _: Context) Result {
+        const b = try self.buf_for_update();
+        const text, const root = try self.cut_to(move_cursor_end_vim, b.root);
+        self.set_clipboard_internal(text);
+        try self.update_buf(root);
+        self.clamp();
+    }
+    pub const cut_to_end_vim_meta = .{ .description = "Cut to end of line (vim)" };
 
     pub fn join_next_line(self: *Self, _: Context) Result {
         const b = try self.buf_for_update();

--- a/src/tui/editor.zig
+++ b/src/tui/editor.zig
@@ -2032,7 +2032,7 @@ pub const Editor = struct {
     fn is_eol_vim(root: Buffer.Root, cursor: *const Cursor, metrics: Buffer.Metrics) bool {
         const line_width = root.line_width(cursor.row, metrics) catch return true;
         if (line_width == 0) return true;
-        if (cursor.col == line_width)
+        if (cursor.col >= line_width)
             return true;
         return false;
     }
@@ -3476,11 +3476,11 @@ pub const Editor = struct {
     pub const cancel_meta = .{ .description = "Cancel current action" };
 
     pub fn select_line_vim(self: *Self, _: Context) Result {
-        const primary = self.get_primary();
-        const root = self.buf_root() catch return;
-        primary.disable_selection(root, self.metrics);
         self.selection_mode = .line;
-        try self.select_line_around_cursor(primary);
+        for (self.cursels.items) |*cursel_| if (cursel_.*) |*cursel|
+            try self.select_line_around_cursor(cursel);
+        self.collapse_cursors();
+ 
         self.clamp();
     }
     pub const select_line_vim_meta = .{ .description = "Select the line around the cursor (vim)" };

--- a/src/tui/editor.zig
+++ b/src/tui/editor.zig
@@ -3536,12 +3536,33 @@ pub const Editor = struct {
     }
     pub const select_word_left_meta = .{ .description = "Select left by word" };
 
+    pub fn select_word_left_vim(self: *Self, _: Context) Result {
+        const root = try self.buf_root();
+        try self.with_selections_const(root, move_cursor_word_left_vim);
+        self.clamp();
+    }
+    pub const select_word_left_vim_meta = .{ .description = "Select left by word (vim)" };
+
     pub fn select_word_right(self: *Self, _: Context) Result {
         const root = try self.buf_root();
         try self.with_selections_const(root, move_cursor_word_right);
         self.clamp();
     }
     pub const select_word_right_meta = .{ .description = "Select right by word" };
+
+    pub fn select_word_right_vim(self: *Self, _: Context) Result {
+        const root = try self.buf_root();
+        try self.with_selections_const(root, move_cursor_word_right_vim);
+        self.clamp();
+    }
+    pub const select_word_right_vim_meta = .{ .description = "Select right by word (vim)" };
+
+    pub fn select_word_right_end_vim(self: *Self, _: Context) Result {
+        const root = try self.buf_root();
+        try self.with_selections_const(root, move_cursor_word_right_end_vim);
+        self.clamp();
+    }
+    pub const select_word_right_end_vim_meta = .{ .description = "Select right by end of word (vim)" };
 
     pub fn select_word_begin(self: *Self, _: Context) Result {
         const root = try self.buf_root();


### PR DESCRIPTION
Removed the possibility of the cursor being in the `LF` position in **NORMAL** mode (for the most part, some cases are more complicated, but should be fine :)). This was accomplished by replacing the vertical movement commands with VIM counterparts that check for an `LF` after the movement was performed.
Added simple indent and unindent bindings.
Added Visual Line mode, with corresponding bindings, mostly from already existing commands.
Replaced `delete_to_end` commands with `cut_to_end` commands.
Replaced `move_scroll_page_up` and `move_scroll_page_down` with half scroll commands instead, for more accurate VIM behaviour.
Added `c`, `C` keybinds and some other small things I can't remember now.