### PR TITLE
Allow .cmd along with .exe for Windows paths

### DIFF
--- a/src/bin_path.zig
+++ b/src/bin_path.zig
@@ -28,18 +28,23 @@ fn find_binary_in_path_windows(allocator: std.mem.Allocator, binary_name_: []con
         error.EnvironmentVariableNotFound, error.InvalidWtf8 => &.{},
     };
     defer allocator.free(bin_paths);
-    const extensions = [_][]const u8{".exe", ".cmd"};
-    for (extensions) |extension| {
-        var path = std.ArrayList(u8).init(allocator);
-        try path.appendSlice(binary_name_);
-        try path.appendSlice(extension);
-        const binary_name = try path.toOwnedSlice();
-        defer allocator.free(binary_name);
-        var bin_path_iterator = std.mem.splitScalar(u8, bin_paths, std.fs.path.delimiter);
-        while (bin_path_iterator.next()) |bin_path| {
-            if (!std.fs.path.isAbsolute(bin_path)) continue;
-            var dir = std.fs.openDirAbsolute(bin_path, .{}) catch continue;
-            defer dir.close();
+    const bin_extensions = std.process.getEnvVarOwned(allocator, "PATHEXT") catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        error.EnvironmentVariableNotFound, error.InvalidWtf8 => &.{},
+    };
+    defer allocator.free(bin_extensions);
+    var bin_path_iterator = std.mem.splitScalar(u8, bin_paths, std.fs.path.delimiter);
+    while (bin_path_iterator.next()) |bin_path| {
+        if (!std.fs.path.isAbsolute(bin_path)) continue;
+        var dir = std.fs.openDirAbsolute(bin_path, .{}) catch continue;
+        defer dir.close();
+        var bin_extensions_iterator = std.mem.splitScalar(u8, bin_extensions, ';');
+        while (bin_extensions_iterator.next()) |bin_extension| {
+            var path = std.ArrayList(u8).init(allocator);
+            try path.appendSlice(binary_name_);
+            try path.appendSlice(bin_extension);
+            const binary_name = try path.toOwnedSlice();
+            defer allocator.free(binary_name);
             _ = dir.statFile(binary_name) catch continue;
             const resolved_binary_path = try std.fs.path.join(allocator, &[_][]const u8{ bin_path, binary_name });
             defer allocator.free(resolved_binary_path);

--- a/src/bin_path.zig
+++ b/src/bin_path.zig
@@ -28,20 +28,23 @@ fn find_binary_in_path_windows(allocator: std.mem.Allocator, binary_name_: []con
         error.EnvironmentVariableNotFound, error.InvalidWtf8 => &.{},
     };
     defer allocator.free(bin_paths);
-    var path = std.ArrayList(u8).init(allocator);
-    try path.appendSlice(binary_name_);
-    try path.appendSlice(".exe");
-    const binary_name = try path.toOwnedSlice();
-    defer allocator.free(binary_name);
-    var bin_path_iterator = std.mem.splitScalar(u8, bin_paths, std.fs.path.delimiter);
-    while (bin_path_iterator.next()) |bin_path| {
-        if (!std.fs.path.isAbsolute(bin_path)) continue;
-        var dir = std.fs.openDirAbsolute(bin_path, .{}) catch continue;
-        defer dir.close();
-        _ = dir.statFile(binary_name) catch continue;
-        const resolved_binary_path = try std.fs.path.join(allocator, &[_][]const u8{ bin_path, binary_name });
-        defer allocator.free(resolved_binary_path);
-        return try allocator.dupeZ(u8, resolved_binary_path);
+    const extensions = [_][]const u8{".exe", ".cmd"};
+    for (extensions) |extension| {
+        var path = std.ArrayList(u8).init(allocator);
+        try path.appendSlice(binary_name_);
+        try path.appendSlice(extension);
+        const binary_name = try path.toOwnedSlice();
+        defer allocator.free(binary_name);
+        var bin_path_iterator = std.mem.splitScalar(u8, bin_paths, std.fs.path.delimiter);
+        while (bin_path_iterator.next()) |bin_path| {
+            if (!std.fs.path.isAbsolute(bin_path)) continue;
+            var dir = std.fs.openDirAbsolute(bin_path, .{}) catch continue;
+            defer dir.close();
+            _ = dir.statFile(binary_name) catch continue;
+            const resolved_binary_path = try std.fs.path.join(allocator, &[_][]const u8{ bin_path, binary_name });
+            defer allocator.free(resolved_binary_path);
+            return try allocator.dupeZ(u8, resolved_binary_path);
+        }
     }
     return null;
 }

--- a/src/syntax/src/file_types.zig
+++ b/src/syntax/src/file_types.zig
@@ -389,6 +389,7 @@ pub const php = .{
     .extensions = .{"php"},
     .comment = "//",
     .injections = "tree-sitter-php/queries/injections.scm",
+    .language_server = .{"intelephense", "--stdio"},
 };
 
 pub const purescript = .{


### PR DESCRIPTION
Hi,

Some LSPs that I run on Windows installed through npm have the `.cmd` extension as opposed to `.exe` (like `intelephense.cmd` that I sent a PR for in https://github.com/neurocyte/flow/pull/186).

This is a small change, but I'm new to Zig, so if there's a better way or if there are any issues do let me know.

Thanks!