### PR TITLE
fix: open recent file ignoring page up/down

### DIFF
--- a/src/tui/mode/overlay/open_recent.zig
+++ b/src/tui/mode/overlay/open_recent.zig
@@ -289,6 +289,16 @@ const cmds = struct {
     }
     pub const palette_menu_up_meta = .{};
 
+    pub fn palette_menu_pagedown(self: *Self, _: Ctx) Result {
+        self.menu.select_last();
+    }
+    pub const palette_menu_pagedown_meta = .{};
+
+    pub fn palette_menu_pageup(self: *Self, _: Ctx) Result {
+        self.menu.select_first();
+    }
+    pub const palette_menu_pageup_meta = .{};
+
     pub fn palette_menu_activate(self: *Self, _: Ctx) Result {
         self.menu.activate_selected();
     }


### PR DESCRIPTION
Hi,

I noticed that page up/down showed an error for the "open recent file" overlay. After reading the code I understand that paging doesn't make much sense since only the first 25 files are shown and the list content is dynamically changed when typing. Either way, I think jumping with page up/down to the start/end of the menu is better than showing `CommandNotFound: menu_page_up`/down.