### PR TITLE
feat: save file without formatting

### DIFF
--- a/src/tui/editor.zig
+++ b/src/tui/editor.zig
@@ -4294,14 +4294,14 @@ pub const Editor = struct {
     }
     pub const open_scratch_buffer_meta = .{ .arguments = &.{ .string, .string } };
 
-    pub fn save_file(self: *Self, ctx: Context) Result {
+    pub fn format_and_save_file(self: *Self, ctx: Context, format_file: bool) Result {
         var then = false;
         var cmd: []const u8 = undefined;
         var args: []const u8 = undefined;
         if (ctx.args.match(.{ "then", .{ tp.extract(&cmd), tp.extract_cbor(&args) } }) catch false) {
             then = true;
         }
-        if (tui.config().enable_format_on_save) if (self.get_formatter()) |_| {
+        if (format_file and tui.config().enable_format_on_save) if (self.get_formatter()) |_| {
             self.need_save_after_filter = .{ .then = if (then) .{ .cmd = cmd, .args = args } else null };
             const primary = self.get_primary();
             const sel = primary.selection;
@@ -4314,7 +4314,16 @@ pub const Editor = struct {
         if (then)
             return command.executeName(cmd, .{ .args = .{ .buf = args } });
     }
+
+    pub fn save_file(self: *Self, ctx: Context) Result {
+        return self.format_and_save_file(ctx, true);
+    }
     pub const save_file_meta = .{ .description = "Save file" };
+
+    pub fn save_file_without_formatting(self: *Self, ctx: Context) Result {
+        return self.format_and_save_file(ctx, false);
+    }
+    pub const save_file_without_formatting_meta = .{ .description = "Save file without formatting" };
 
     pub fn save_file_as(self: *Self, ctx: Context) Result {
         var file_path: []const u8 = undefined;


### PR DESCRIPTION
I didn't find a way to use flow when I have to do a minor edit to a file that has legacy formatting, except by uninstalling the formatting tool.