### PR TITLE
fix(helix): Making `d` and `c` work as expected in normal mode

### DIFF
--- a/src/keybind/builtin/helix.json
+++ b/src/keybind/builtin/helix.json
@@ -146,8 +146,8 @@
             ["a", ["move_right"], ["enter_mode", "insert"]],
             ["o", ["smart_insert_line_after"], ["enter_mode", "insert"]],
 
-            ["d", "cut"],
-            ["c", ["cut"], ["enter_mode", "insert"]],
+            ["d", "cut_forward_internal"],
+            ["c", ["cut_forward_internal"], ["enter_mode", "insert"]],
 
             ["s", "select_regex"],
             [";", "collapse_selections"],

--- a/src/tui/editor.zig
+++ b/src/tui/editor.zig
@@ -2495,7 +2495,14 @@ pub const Editor = struct {
                 continue;
             }
 
-            with_selection_const(root, move, cursel, self.metrics) catch continue;
+            switch (tui.get_selection_style()) {
+                .inclusive => {
+                    const sel = try cursel.enable_selection(root, self.metrics);
+                    cursel.cursor = sel.end;
+                    cursel.check_selection(root, self.metrics);
+                },
+                else => with_selection_const(root, move, cursel, self.metrics) catch continue,
+            }
             const cut_text, root = self.cut_selection(root, cursel) catch continue;
 
             if (first) {


### PR DESCRIPTION
Currently the Helix normal mode uses the `cut` function for the `d` and `c` bindings:

https://github.com/neurocyte/flow/blob/b30a5d4819ca2b7e8835d8fe18aa4956f61a5a83/src/keybind/builtin/helix.json#L149-L150

...which leads to unintended behavior because that deletes the whole line. Looking at the Vim bindings for the `x` binding, which has a similar behavior, it is used the `cut_forward_internal` function. Trying to use this same function for the helix `d` and `c` actions also leads to unintended behaviors because it deletes both the character under the cursor and the next as result of the `inclusive_selection`. So this PR adds a switch statement to the `cut_to` function, used by the `cut_forward_internal` function, to handle the `inclusive_selection` of helix so it can be use properly on the bindings of `d` and `c` .

This is more like a temporary fix, since it is deforming the behavior of `cut_to` by cancelling your `move` parameter in the case of `inclusive_selection`. As such, a more elegant solution can be developed in the future.

Related issue: #206 