### PR TITLE
Helix mode: adding commands

### DIFF
--- a/src/keybind/builtin/helix.json
+++ b/src/keybind/builtin/helix.json
@@ -204,7 +204,7 @@
             ["page_up", "move_scroll_page_up"],
             ["page_down", "move_scroll_page_down"],
 
-            ["space shift+f", "file_picker_in_current_directory"],
+            ["space shift+f", "find_file"],
             ["space shift+s", "workspace_symbol_picker"],
             ["space shift+d", "workspace_diagnostics_picker"],
             ["space shift+p", "system_paste"],

--- a/src/keybind/builtin/helix.json
+++ b/src/keybind/builtin/helix.json
@@ -62,7 +62,7 @@
 
             ["shift+`", "switch_case"],
             ["shift+t", "till_prev_char"],
-            ["shift+f", "move_to_char", false],
+            ["shift+f", "move_to_char", "left"],
             ["shift+w", "move_next_long_word_start"],
             ["shift+b", "move_prev_long_word_start"],
             ["shift+e", "move_next_long_word_end"],
@@ -107,7 +107,7 @@
             ["l", "move_right"],
 
             ["t", "find_till_char"],
-            ["f", "move_to_char", true],
+            ["f", "move_to_char", "right"],
 
             ["`", "to_lower"],
 

--- a/src/keybind/builtin/helix.json
+++ b/src/keybind/builtin/helix.json
@@ -210,7 +210,7 @@
             ["space shift+p", "system_paste"],
             ["space shift+r", "replace_selections_with_clipboard"],
             ["space shift+/", "open_command_palette"],
-            ["space f", "file_picker"],
+            ["space f", "find_file"],
             ["space b", "buffer_picker"],
             ["space j", "jumplist_picker"],
             ["space s", "symbol_picker"],

--- a/src/tui/editor.zig
+++ b/src/tui/editor.zig
@@ -103,7 +103,7 @@ pub const CurSel = struct {
         };
     }
 
-    fn enable_selection_normal(self: *Self) *Selection {
+    pub fn enable_selection_normal(self: *Self) *Selection {
         return if (self.selection) |*sel|
             sel
         else cod: {
@@ -501,7 +501,7 @@ pub const Editor = struct {
         return self.buffer orelse error.Stop;
     }
 
-    fn buf_root(self: *const Self) !Buffer.Root {
+    pub fn buf_root(self: *const Self) !Buffer.Root {
         return if (self.buffer) |p| p.root else error.Stop;
     }
 
@@ -1649,7 +1649,7 @@ pub const Editor = struct {
         self.view.col = dest.col;
     }
 
-    inline fn clamp(self: *Self) void {
+    pub inline fn clamp(self: *Self) void {
         self.clamp_abs(false);
     }
 
@@ -2101,7 +2101,7 @@ pub const Editor = struct {
             move_cursor_left(root, cursor, metrics) catch return;
     }
 
-    fn move_cursor_begin(_: Buffer.Root, cursor: *Cursor, _: Buffer.Metrics) !void {
+    pub fn move_cursor_begin(_: Buffer.Root, cursor: *Cursor, _: Buffer.Metrics) !void {
         cursor.move_begin();
     }
 
@@ -2124,7 +2124,7 @@ pub const Editor = struct {
             move_cursor_right(root, cursor, metrics) catch return;
     }
 
-    fn move_cursor_end(root: Buffer.Root, cursor: *Cursor, metrics: Buffer.Metrics) !void {
+    pub fn move_cursor_end(root: Buffer.Root, cursor: *Cursor, metrics: Buffer.Metrics) !void {
         cursor.move_end(root, metrics);
     }
 

--- a/src/tui/editor.zig
+++ b/src/tui/editor.zig
@@ -1775,7 +1775,7 @@ pub const Editor = struct {
         cursel.check_selection(root, metrics);
     }
 
-    fn with_selections_const(self: *Self, root: Buffer.Root, move: cursor_operator_const) error{Stop}!void {
+    pub fn with_selections_const(self: *Self, root: Buffer.Root, move: cursor_operator_const) error{Stop}!void {
         var someone_stopped = false;
         for (self.cursels.items) |*cursel_| if (cursel_.*) |*cursel|
             with_selection_const(root, move, cursel, self.metrics) catch {
@@ -1994,7 +1994,7 @@ pub const Editor = struct {
         return !cursor.test_at(root, is_whitespace_or_eol, metrics);
     }
 
-    fn is_word_boundary_left_vim(root: Buffer.Root, cursor: *const Cursor, metrics: Buffer.Metrics) bool {
+    pub fn is_word_boundary_left_vim(root: Buffer.Root, cursor: *const Cursor, metrics: Buffer.Metrics) bool {
         if (is_whitespace_at_cursor(root, cursor, metrics)) return false;
         var next = cursor.*;
         next.move_left(root, metrics) catch return true;
@@ -2087,11 +2087,11 @@ pub const Editor = struct {
         return false;
     }
 
-    fn move_cursor_left(root: Buffer.Root, cursor: *Cursor, metrics: Buffer.Metrics) error{Stop}!void {
+    pub fn move_cursor_left(root: Buffer.Root, cursor: *Cursor, metrics: Buffer.Metrics) error{Stop}!void {
         try cursor.move_left(root, metrics);
     }
 
-    fn move_cursor_left_until(root: Buffer.Root, cursor: *Cursor, pred: cursor_predicate, metrics: Buffer.Metrics) void {
+    pub fn move_cursor_left_until(root: Buffer.Root, cursor: *Cursor, pred: cursor_predicate, metrics: Buffer.Metrics) void {
         while (!pred(root, cursor, metrics))
             move_cursor_left(root, cursor, metrics) catch return;
     }

--- a/src/tui/editor.zig
+++ b/src/tui/editor.zig
@@ -1921,7 +1921,7 @@ pub const Editor = struct {
     const cursel_operator = *const fn (root: Buffer.Root, cursel: *CurSel, allocator: Allocator) error{Stop}!Buffer.Root;
     const cursel_operator_mut = *const fn (self: *Self, root: Buffer.Root, cursel: *CurSel, allocator: Allocator) error{Stop}!Buffer.Root;
 
-    fn is_not_word_char(c: []const u8) bool {
+    pub fn is_not_word_char(c: []const u8) bool {
         if (c.len == 0) return true;
         return switch (c[0]) {
             ' ' => true,
@@ -1962,7 +1962,7 @@ pub const Editor = struct {
         return cursor.test_at(root, is_word_char, metrics);
     }
 
-    fn is_non_word_char_at_cursor(root: Buffer.Root, cursor: *const Cursor, metrics: Buffer.Metrics) bool {
+    pub fn is_non_word_char_at_cursor(root: Buffer.Root, cursor: *const Cursor, metrics: Buffer.Metrics) bool {
         return cursor.test_at(root, is_not_word_char, metrics);
     }
 
@@ -1986,7 +1986,7 @@ pub const Editor = struct {
         return is_whitespace(c) or c[0] == '\n';
     }
 
-    fn is_whitespace_at_cursor(root: Buffer.Root, cursor: *const Cursor, metrics: Buffer.Metrics) bool {
+    pub fn is_whitespace_at_cursor(root: Buffer.Root, cursor: *const Cursor, metrics: Buffer.Metrics) bool {
         return cursor.test_at(root, is_whitespace, metrics);
     }
 

--- a/src/tui/mode/helix.zig
+++ b/src/tui/mode/helix.zig
@@ -6,6 +6,8 @@ const cmd = command.executeName;
 
 const tui = @import("../tui.zig");
 const Editor = @import("../editor.zig").Editor;
+const Buffer = @import("Buffer");
+const Cursor = Buffer.Cursor;
 
 var commands: Commands = undefined;
 
@@ -93,4 +95,38 @@ const cmds_ = struct {
         ed.clamp();
     }
     pub const extend_line_below_meta: Meta = .{ .description = "Select current line, if already selected, extend to next line" };
+
+    pub fn move_next_word_start(_: *void, _: Ctx) Result {
+        const mv = tui.mainview() orelse return;
+        const ed = mv.get_active_editor() orelse return;
+        const root = try ed.buf_root();
+
+        for (ed.cursels.items) |*cursel_| if (cursel_.*) |*cursel| {
+            cursel.selection = null;
+        };
+
+        ed.with_selections_const(root, Editor.move_cursor_word_right_vim) catch {};
+        ed.clamp();
+    }
+
+    pub const move_next_word_start_meta: Meta = .{ .description = "Move next word start" };
+
+    pub fn move_prev_word_start(_: *void, _: Ctx) Result {
+        const mv = tui.mainview() orelse return;
+        const ed = mv.get_active_editor() orelse return;
+        const root = try ed.buf_root();
+
+        for (ed.cursels.items) |*cursel_| if (cursel_.*) |*cursel| {
+            cursel.selection = null;
+        };
+
+        ed.with_selections_const(root, move_cursor_word_left_helix) catch {};
+        ed.clamp();
+    }
+    pub const move_prev_word_start_meta: Meta = .{ .description = "Move previous word start" };
 };
+
+pub fn move_cursor_word_left_helix(root: Buffer.Root, cursor: *Cursor, metrics: Buffer.Metrics) error{Stop}!void {
+    try Editor.move_cursor_left(root, cursor, metrics);
+    Editor.move_cursor_left_until(root, cursor, Editor.is_word_boundary_left_vim, metrics);
+}


### PR DESCRIPTION
This PR aims to implement or correct the following helix commands:

- [x] `x` -> `extend_line_below` 5b42a3c
- [x] `space shift+f` -> `file_picker_at_current_directory` c36315c
- [x] `f` -> `find_next_char` fd2e3a5
- [x] `shift f` -> `find_previous_char` fd2e3a5
- [x] `w` -> `move_next_word_start`
- [x] `b` -> `move_prev_word_start`

When all the list commands are implemented, the PR will be marked as Ready for review.

Related issue: #206 