### PR TITLE
fix move_next_word_end

### DIFF
--- a/src/tui/mode/helix.zig
+++ b/src/tui/mode/helix.zig
@@ -132,7 +132,8 @@ const cmds_ = struct {
         const root = try ed.buf_root();
 
         for (ed.cursels.items) |*cursel_| if (cursel_.*) |*cursel| {
-            cursel.disable_selection(root, ed.metrics);
+            // cursel.disable_selection(root, ed.metrics);
+            cursel.selection = null;
         };
 
         ed.with_selections_const_repeat(root, move_cursor_word_right_end_helix, ctx) catch {};

--- a/src/tui/mode/helix.zig
+++ b/src/tui/mode/helix.zig
@@ -132,7 +132,6 @@ const cmds_ = struct {
         const root = try ed.buf_root();
 
         for (ed.cursels.items) |*cursel_| if (cursel_.*) |*cursel| {
-            // cursel.disable_selection(root, ed.metrics);
             cursel.selection = null;
         };
 


### PR DESCRIPTION
Turns out that `selection = null` was the right approach. `.disable_selection` preserves selected the char originally under cursor, which is not the intended behavior.