### PR TITLE
Fix: Assert hit when exceeding inputbox's item's length in palette.zig.

### DIFF
--- a/src/tui/mode/overlay/palette.zig
+++ b/src/tui/mode/overlay/palette.zig
@@ -213,6 +213,7 @@ pub fn Create(options: type) type {
             self.items = 0;
             self.menu.reset_items();
             self.menu.selected = null;
+            self.longest = self.inputbox.text.items.len;
             for (self.entries.items) |entry|
                 self.longest = @max(self.longest, entry.label.len);
 


### PR DESCRIPTION
Fixes the palette crashing when input exceeding its longest item by expanding the input box.