### PR TITLE
feat: update nix and web-based langs

### DIFF
--- a/src/syntax/src/file_types.zig
+++ b/src/syntax/src/file_types.zig
@@ -88,6 +88,7 @@ pub const css = .{
     .icon = "󰌜",
     .extensions = .{"css"},
     .comment = "//",
+    .language_server = .{ "vscode-css-language-server", "--stdio" },
 };
 
 pub const diff = .{
@@ -230,15 +231,16 @@ pub const javascript = .{
     .extensions = .{"js"},
     .comment = "//",
     .injections = "tree-sitter-javascript/queries/injections.scm",
-    .language_server = .{ "deno", "lsp" },
+    .language_server = .{ "typescript-language-server", "--stdio" },
+    .formatter = .{"prettier"},
 };
 
 pub const json = .{
     .description = "JSON",
     .extensions = .{"json"},
     .comment = "//",
-    .language_server = .{ "deno", "lsp" },
-    .formatter = .{ "hjson", "-j" },
+    .language_server = .{ "vscode-json-language-server", "--stdio" },
+    .formatter = .{"prettier"},
 };
 
 pub const julia = .{
@@ -293,7 +295,8 @@ pub const markdown = .{
     .comment = "<!--",
     .highlights = "tree-sitter-markdown/tree-sitter-markdown/queries/highlights.scm",
     .injections = "tree-sitter-markdown/tree-sitter-markdown/queries/injections.scm",
-    .language_server = .{ "deno", "lsp" },
+    .language_server = .{ "marksman", "server" },
+    .formatter = .{"prettier"},
 };
 
 pub const @"markdown-inline" = .{
@@ -345,6 +348,8 @@ pub const nix = .{
     .extensions = .{"nix"},
     .comment = "#",
     .injections = "tree-sitter-nix/queries/injections.scm",
+    .language_server = .{"nixd"},
+    .formatter = .{"alejandra"},
 };
 
 pub const nu = .{
@@ -517,7 +522,8 @@ pub const typescript = .{
     .icon = "󰛦",
     .extensions = .{ "ts", "tsx" },
     .comment = "//",
-    .language_server = .{ "deno", "lsp" },
+    .language_server = .{ "typescript-language-server", "--stdio" },
+    .formatter = .{"prettier"},
 };
 
 pub const typst = .{


### PR DESCRIPTION
This will update lsp clients and formatters for this languages:
- Markdown
- Nix
- TypeScript
- JavaScript
- JSON
- CSS

There are some problems when using these options:

1. Nix formatter `alejandra` will do nothing with or without `-` option. When saving editor just says `no changes to save`, yet the file itself is saved. `nixd` lsp works without issues.
2. `typescript-language-server` works with goto definitions, but on errors editor will throw `Invalid Message Field` error.
3. On save with prettier as a formatter editor will throw `filter: ERR: [error]: no parser and no file path given, couldn't infer a parser`
4. `vscode-json-language-server` gives no errors and has no usable features, same with `vscode-css-language-server`