### PR TITLE
harmonize selection display

### DIFF
--- a/src/tui/status/selectionstate.zig
+++ b/src/tui/status/selectionstate.zig
@@ -69,7 +69,7 @@ fn format(self: *Self) void {
         sel.normalize();
         const lines = sel.end.row - sel.begin.row;
         if (lines == 0) {
-            std.fmt.format(writer, "({d} selected)", .{sel.end.col - sel.begin.col}) catch {};
+            std.fmt.format(writer, "({d} columns selected)", .{sel.end.col - sel.begin.col}) catch {};
         } else {
             std.fmt.format(writer, "({d} lines selected)", .{if (sel.end.col == 0) lines else lines + 1}) catch {};
         }


### PR DESCRIPTION
I was initially confused about "(4 selected)" in the status bar -- 4 "what"?  Especially because often, it is preceded by "(N matches)".

This harmonizes the display of an in-line selection with the multi-line case, and shows that it's a certain number of "chars" that are selected.