### PR TITLE
`file_types`: invoke `OmniSharp` instead of `omnisharp`

### DIFF
--- a/src/syntax/src/file_types.zig
+++ b/src/syntax/src/file_types.zig
@@ -41,7 +41,7 @@ pub const @"c-sharp" = .{
     .icon = "󰌛",
     .extensions = .{"cs"},
     .comment = "//",
-    .language_server = .{ "omnisharp", "-lsp" },
+    .language_server = .{ "OmniSharp", "-lsp" },
     .formatter = .{ "csharpier", "format" },
 };
 


### PR DESCRIPTION
The former is the canonical executable name, and also what Helix uses. Seems reasonable to standardize on that.