### PR TITLE
feat: add helix mode close other buffers and reload all

### DIFF
--- a/help.md
+++ b/help.md
@@ -22,15 +22,23 @@ ctrl+n/ctrl+p or f3/shift+f3 to jump through the matches. Press Enter
 to exit find mode at the current match or Escape to return to your
 starting point.
 
+## Messages and logs
+
+Messages of issues regarding tasks that are not accomplished are
+reported to the log view, to open it, use ctrl+shift+p > View log. For
+example, when you try to close a buffer that is not saved, or try to
+exit Flow without all the buffers saved, it will be reported in the log.
+
+
 ## Input Modes
 
 Flow Control supports multiple input modes that may be changed
 interactively at runtime. The current input mode (and some other
 settings) is persisted in the configuration file automatically.
 
-- f4 => Cycle major input modes (flow, vim, ...)
+- f4 => Cycle major input modes (flow, emacs, vim, helix,...)
 
-The current input mode is displayed in the at the left side of the statusbar.
+The current input mode is displayed at the left side of the statusbar.
 
 - ctrl+shift+p or alt+x => Show the command palette
 
@@ -102,15 +110,26 @@ list of keybindings for this mode.
 
 The vim modes, shown as NORMAL, INSERT or VISUAL in the status bar,
 follow the basic modal editing style of vim. The basics follow vim
-closely, but more advanced vim functions (e.g. macrosand registers)
+closely, but more advanced vim functions (e.g. macros and registers)
 are not supported (yet). Keybindings from flow mode that do not conflict
 with vim keybindings also work in vim mode.
+
+## Helix mode
+
+The Helix modes, shown as NOR, INS or SEL in the status bar, follow
+the basic modal editing style of Helix. The basics are being adapted
+closely, more advanced functions (e.g. surround, macros,
+selections, registers) are not supported (yet). Usual keybinding
+with LSPs are used for tasks like 'go to definition', 'go to reference'
+and 'inline documentation' featuring inline diagnostics. Keybindings
+from flow mode that do not conflict with helix keybindings also work in
+helix mode.
 
 (work in progress)
 
 ### Mouse Commands
 
-Mouse commands are not rebindable and are not listed in the command palette.
+Mouse commands are NOT rebindable and are not listed in the command palette.
 
 - Left Click =>
         Clear all cursors and selections and the place cursor at the mouse pointer
@@ -170,7 +189,7 @@ animation_min_lag 0
 animation_max_lag 150
 ```
 
-Most of these options are fairly self explanitory.
+Most of these options are fairly self explanatory.
 
 `theme`, `input_mode` and `show_whitespace` are automatically
 persisted when changed interactively with keybindings.

--- a/help.md
+++ b/help.md
@@ -15,6 +15,7 @@ kitty_mod ctrl+alt
 For other editors you will probably have to disable or rebind them each
 individually.
 
+
 ## Searching
 
 Press ctrl+f to search this help file. Type a search term and press 
@@ -22,12 +23,15 @@ ctrl+n/ctrl+p or f3/shift+f3 to jump through the matches. Press Enter
 to exit find mode at the current match or Escape to return to your
 starting point.
 
+
 ## Messages and logs
 
-Messages of issues regarding tasks that are not accomplished are
-reported to the log view, to open it, use ctrl+shift+p > View log. For
-example, when you try to close a buffer that is not saved, or try to
-exit Flow without all the buffers saved, it will be reported in the log.
+Messages of issues regarding tasks that are not accomplished, like
+trying to close flow with unsaved files, as well as other information
+are shown briefly in the bottom status bar; most recent messages can
+be seen in the log view too, to open it, use ctrl+shift+p > `View log`;
+it's possible to make it taller dragging the toolbar with the mouse
+up or downwards.
 
 
 ## Input Modes
@@ -95,18 +99,19 @@ Multiple inheritance is supported with the `inherits` options like this:
         ...
 ```
 
-## Flow mode
+### Flow mode
 
 The default input mode, called just flow, is based on common GUI
 programming editors. It most closely resembles Visual Studio Code, but
 also takes some inspiration from Emacs and others. This mode focuses
-on powerful multi cursor support with a find -> select -> modify 
+on powerful multi cursor support with a find -> select -> modify
 cycle style of editing.
 
 See the `ctrl+f2` palette when flow mode is selected to see the full
 list of keybindings for this mode.
 
-## Vim mode
+
+### Vim mode
 
 The vim modes, shown as NORMAL, INSERT or VISUAL in the status bar,
 follow the basic modal editing style of vim. The basics follow vim
@@ -114,20 +119,21 @@ closely, but more advanced vim functions (e.g. macros and registers)
 are not supported (yet). Keybindings from flow mode that do not conflict
 with vim keybindings also work in vim mode.
 
-## Helix mode
 
-The Helix modes, shown as NOR, INS or SEL in the status bar, follow
-the basic modal editing style of Helix. The basics are being adapted
-closely, more advanced functions (e.g. surround, macros,
-selections, registers) are not supported (yet). Usual keybinding
-with LSPs are used for tasks like 'go to definition', 'go to reference'
-and 'inline documentation' featuring inline diagnostics. Keybindings
+### Helix mode
+
+The helix modes, shown as NOR, INS or SEL in the status bar, follow
+the basic modal editing style of helix. The basics are being adapted
+closely, more advanced functions (e.g. surround, macros, selections,
+registers) are not supported (yet). Usual keybinding with LSPs are
+used for tasks like 'go to definition', 'go to reference' and
+'inline documentation' featuring inline diagnostics. Keybindings
 from flow mode that do not conflict with helix keybindings also work in
 helix mode.
 
 (work in progress)
 
-### Mouse Commands
+## Mouse Commands
 
 Mouse commands are NOT rebindable and are not listed in the command palette.
 
@@ -204,3 +210,9 @@ animation altogether.
 File types may be configured with the `Edit file type configuration` command. You
 can also create a new file type by adding a new `.conf` file to the `file_type`
 directory. Have a look at an existing file type to see what options are available.
+
+## Flags and options
+
+As every respectable terminal program, flow provide various invoking
+options that among others, will allow you to inspect various aspects of
+the running session.  Feel free to run `flow --help` to explore them.

--- a/src/tui/mainview.zig
+++ b/src/tui/mainview.zig
@@ -273,7 +273,13 @@ const cmds = struct {
     const Result = command.Result;
 
     pub fn quit(self: *Self, _: Ctx) Result {
-        try self.check_all_not_dirty();
+        const logger = log.logger("buffer");
+        defer logger.deinit();
+        self.check_all_not_dirty() catch |err| {
+            const dirties = self.buffer_manager.number_of_dirties();
+            logger.print("There are {} unsaved buffer(s), use 'quit without saving' if not needed to save them", .{dirties});
+            return err;
+        };
         try tp.self_pid().send("quit");
     }
     pub const quit_meta: Meta = .{ .description = "Quit" };

--- a/src/tui/mainview.zig
+++ b/src/tui/mainview.zig
@@ -276,8 +276,8 @@ const cmds = struct {
         const logger = log.logger("buffer");
         defer logger.deinit();
         self.check_all_not_dirty() catch |err| {
-            const dirties = self.buffer_manager.number_of_dirties();
-            logger.print("There are {} unsaved buffer(s), use 'quit without saving' if not needed to save them", .{dirties});
+            const count_dirty_buffers = self.buffer_manager.count_dirty_buffers();
+            logger.print("{} unsaved buffer(s), use 'quit without saving' to exit", .{count_dirty_buffers});
             return err;
         };
         try tp.self_pid().send("quit");

--- a/src/tui/mode/helix.zig
+++ b/src/tui/mode/helix.zig
@@ -163,9 +163,16 @@ const cmds_ = struct {
     pub const @"bco!_meta": Meta = .{ .description = "bco! (Close other buffers/tabs forcefully, ignoring changes)" };
 
     pub fn bco(_: *void, _: Ctx) Result {
+        const logger = log.logger("helix-mode");
+        defer logger.deinit();
         const mv = tui.mainview() orelse return;
         const bm = tui.get_buffer_manager() orelse return;
-        if (mv.get_active_buffer()) |buffer| _ = bm.close_others(buffer);
+        if (mv.get_active_buffer()) |buffer| {
+            const remaining = bm.close_others(buffer);
+            if (remaining > 0) {
+                logger.print("{} unsaved buffer(s) remaining", .{remaining});
+            }
+        }
     }
     pub const bco_meta: Meta = .{ .description = "bco (Close other buffers/tabs, except this one)" };
 


### PR DESCRIPTION

* `:rla` reload all buffers
* `:bco` close other buffers except current
* `:bco!` close all the other buffers even without saved changes
* `:x` saves this buffer and exit if all the others can be closed
* `:x!` saves the current buffer and exit discarding all others changes, if any

We need some mechanism to tell the user why something failed, for example: `:x` can fail, but `:x!` shouldn't.  The following screenshot shows how Helix let the user know that something impeded an action to shoot the foot themselves... .  Maybe a miss on my side if there is one that I didn't see, please point me to the place to put the necessary and I will add corresponding messages in some places.

<img width="496" height="59" alt="transient error message in helix" src="https://github.com/user-attachments/assets/49987046-52fa-4848-a127-e89e7bb8bad2" />
 
