### PR TITLE
refactor: additional characters for smart_insert

### DIFF
--- a/src/buffer/unicode.zig
+++ b/src/buffer/unicode.zig
@@ -41,13 +41,15 @@ pub fn control_code_to_unicode(code: u8) [:0]const u8 {
 pub const char_pairs = [_]struct { []const u8, []const u8 }{
     .{ "\"", "\"" },
     .{ "'", "'" },
+    .{ "`", "`" },
     .{ "(", ")" },
     .{ "[", "]" },
     .{ "{", "}" },
     .{ "‘", "’" },
     .{ "“", "”" },
-    .{ "‚", "‘" },
     .{ "«", "»" },
+    .{ "¿", "?" },
+    .{ "¡", "!" },
 };
 
 pub const open_close_pairs = [_]struct { []const u8, []const u8 }{
@@ -57,6 +59,8 @@ pub const open_close_pairs = [_]struct { []const u8, []const u8 }{
     .{ "‘", "’" },
     .{ "“", "”" },
     .{ "«", "»" },
+    .{ "¿", "?" },
+    .{ "¡", "!" },
 };
 
 fn raw_byte_to_utf8(cp: u8, buf: []u8) ![]const u8 {

--- a/src/keybind/builtin/flow.json
+++ b/src/keybind/builtin/flow.json
@@ -255,6 +255,7 @@
 
             ["\"", "smart_insert_pair", "\"", "\""],
             ["'", "smart_insert_pair", "'", "'"],
+            ["`", "smart_insert_pair", "`", "`"],
             ["(", "smart_insert_pair", "(", ")"],
             [")", "smart_insert_pair_close", "(", ")"],
             ["[", "smart_insert_pair", "[", "]"],
@@ -269,6 +270,8 @@
             ["‘", "smart_insert_pair_close", "‚", "‘"],
             ["«", "smart_insert_pair", "«", "»"],
             ["»", "smart_insert_pair_close", "«", "»"],
+            ["¿", "smart_insert_pair", "¿", "?"],
+            ["¡", "smart_insert_pair", "¡", "!"],
 
             ["alt+0", "add_integer_argument_digit", 0],
             ["alt+1", "add_integer_argument_digit", 1],


### PR DESCRIPTION
¿? and ¡! only opening are added for smart_insert, also added for bracket matching.  `Addded too`, to ease markdown typing.

Unsure about `||`, maybe worth it too?

https://github.com/user-attachments/assets/a56e59ee-2206-4f29-9fee-01787b723ead

