### PR TITLE
feat: ty lsp for python

### DIFF
--- a/src/file_type_lsp.zig
+++ b/src/file_type_lsp.zig
@@ -164,7 +164,7 @@ pub const proto = .{};
 pub const purescript = .{};
 
 pub const python = .{
-    .language_server = .{ "ruff", "server" },
+    .language_server = .{ "uvx", "ty", "server" },
     .formatter = .{ "ruff", "format", "-" },
 };
 


### PR DESCRIPTION
Changing ruff in favor of [ty](https://docs.astral.sh/ty/) which feature symbols and other expected functionalities from LSP.

https://github.com/user-attachments/assets/7140c2e2-e551-40e3-986a-bae2c41876b2

