### PR TITLE
fix: More correct behaviour for Prev/Next word in helix

### DIFF
--- a/src/tui/mode/helix.zig
+++ b/src/tui/mode/helix.zig
@@ -568,7 +568,7 @@ fn extend_to_word(ctx: command.Context, move: Editor.cursor_operator_const, _: D
     var repeat: usize = 1;
     _ = ctx.args.match(.{tp.extract(&repeat)}) catch false;
     for (ed.cursels.items) |*cursel_| if (cursel_.*) |*cursel| {
-        const sel = try cursel.enable_selection(root, ed.metrics);
+        const sel = cursel.enable_selection(root, ed.metrics);
         const pivot: usize = if (sel.is_reversed()) sel.begin.col -| 1 else sel.begin.col;
         var i: usize = repeat;
         while (i > 0) : (i -= 1) {


### PR DESCRIPTION
This PR fixes `move_prev_word_start` not selecting the first character, whilst preserving word boundary skipping consistent with helix. Word boundary skipping is also implemented for `move_next_word_start`.

The extend selection helper function has been modified to correctly preserve the pivot element with the implemented changes.

The code in the PR could be reorganized into different functions for  moving backwards and forwards, just let me know and I'll change it.