### PR TITLE
fix: handle absolute file paths in open file prompt

### DIFF
--- a/src/project_manager.zig
+++ b/src/project_manager.zig
@@ -1040,6 +1040,8 @@ pub fn abbreviate_home(buf: []u8, path: []const u8) []const u8 {
         return "~";
     } else if (homerelpath.len > 3 and std.mem.eql(u8, homerelpath[0..3], "../")) {
         return path;
+    } else if (homerelpath.len + 2 > buf.len) {
+        return path;
     } else {
         buf[0] = '~';
         buf[1] = '/';


### PR DESCRIPTION
Previously, absolute paths were not handled correctly when populating the starting path in the "open file" prompt:

1. Open Flow in some directory (say `/home/example/a`)
2. Open a file in a different directory outside the project (say `/home/example/b`)
3. Bringing up the "open file" prompt would previously populate `~/a//home/example/b` as the initial path

I updated the logic to handle this case, and fixed a couple other minor related things too:

1. Replaced hard-coded `/` logic with the more portable `std.fs.path.dirname`
2. Fixed a potential buffer overflow in `abbreviate_home`