### PR TITLE
fix documentHighlight missing references

### DIFF
--- a/src/tui/editor.zig
+++ b/src/tui/editor.zig
@@ -6200,6 +6200,7 @@ pub const Editor = struct {
     }
 
     pub fn done_highlight_reference(self: *Self) void {
+        self.sort_matches();
         self.highlight_references_state = .done;
     }
 

--- a/src/tui/mainview.zig
+++ b/src/tui/mainview.zig
@@ -165,7 +165,7 @@ pub fn receive(self: *Self, from_: tp.pid_ref, m: tp.message) error{Exit}!bool {
         }
         self.find_in_files_state = .done;
         return true;
-    } else if (try m.match(.{ "HREF", tp.extract(&path), tp.extract(&begin_line), tp.extract(&begin_pos), tp.extract(&end_line), tp.extract(&end_pos), tp.extract(&lines) })) {
+    } else if (try m.match(.{ "HREF", tp.extract(&begin_line), tp.extract(&begin_pos), tp.extract(&end_line), tp.extract(&end_pos) })) {
         if (self.get_active_editor()) |editor| editor.add_highlight_reference(.{
             .begin = .{ .row = begin_line, .col = begin_pos },
             .end = .{ .row = end_line, .col = end_pos },


### PR DESCRIPTION
closes #452
also uses the correct request which fixes it not activating in some places for rust-analyzer (which is the vast majority of the change size :p)
i left `kind` unused for now, wasnt sure how exactly to wire it all up.