### PR TITLE
refactor: crop blame commit summary to always fit author

### DIFF
--- a/src/tui/editor.zig
+++ b/src/tui/editor.zig
@@ -1557,19 +1557,18 @@ pub const Editor = struct {
                 .bg = if (hl_row) |_| theme.editor_line_highlight.bg else theme.editor_hint.bg,
             });
 
-            var summary_freespace: i32 = @intCast(screen_width - space_begin);
             const static_text = "      , ";
-            summary_freespace -= @intCast(static_text.len + commit.author.len);
+            const summary_freespace = screen_width -| (space_begin + static_text.len + commit.author.len);
 
             var buf: std.Io.Writer.Allocating = .init(self.allocator);
             defer buf.deinit();
 
-            if (summary_freespace >= @as(i32, @intCast(commit.summary.len))) {
+            if (summary_freespace >= commit.summary.len) {
                 _ = buf.writer.print("      {s}, {s}", .{ commit.summary, commit.author }) catch 0;
             } else if (summary_freespace <= 3) {
                 _ = buf.writer.print("      {s}", .{commit.author}) catch 0;
             } else {
-                _ = buf.writer.print("      {s}..., {s}", .{ commit.summary[0 .. @as(usize, @intCast(summary_freespace)) - 3], commit.author }) catch 0;
+                _ = buf.writer.print("      {s}..., {s}", .{ commit.summary[0..summary_freespace -| 3], commit.author }) catch 0;
             }
 
             const msg = buf.written();


### PR DESCRIPTION
Hi!

Just a small change to crop the commit summary of the inline blame if it is too long. Eg:

`<code> this is a very long commit summary that is relevant but not so much and I want to see who did it, Committer name`

Converts to:

`<code> this is a very long commit summary that is ..., Committer name`

Image (very small window just for the example)

<img width="865" height="117" alt="Screenshot from 2026-02-11 10-31-31" src="https://github.com/user-attachments/assets/444b4c12-5c73-4251-8221-8b89a526ae37" />

