### PR TITLE
fix: show closed folder icon when folder is not expanded in the tree

### DIFF
--- a/src/tui/mode/overlay/project_file_tree_palette.zig
+++ b/src/tui/mode/overlay/project_file_tree_palette.zig
@@ -171,7 +171,7 @@ fn getNodeIconAndColor(node: *const Node) !struct { []const u8, u24 } {
     if (node.type_ == .folder) {
         if (node.expanded) {
             return .{ "", 0 };
-        } else return .{ "", 0 };
+        } else return .{ "", 0 };
     }
 
     _, const icon_, const color_ = guess_file_type(node.path);


### PR DESCRIPTION
I just realized that somewhere in the process of the last PR we lost the symbol for closed folders.