### PR TITLE
fix(vim): paste crash on empty clipboard

### DIFF
--- a/src/tui/editor.zig
+++ b/src/tui/editor.zig
@@ -3345,6 +3345,11 @@ pub const Editor = struct {
         else
             tui.clipboard_get_group(0);
 
+        if (clipboard.len == 0) {
+            self.logger.print("paste: nothing to paste", .{});
+            return;
+        }
+
         const b = try self.buf_for_update();
         var root = b.root;
 


### PR DESCRIPTION
Fixes #511

matching helix implementation and log message