### PR TITLE
Move right stops at last character

### DIFF
--- a/src/tui/editor.zig
+++ b/src/tui/editor.zig
@@ -3697,7 +3697,15 @@ pub const Editor = struct {
     }
 
     pub fn move_cursor_word_right(root: Buffer.Root, cursor: *Cursor, metrics: Buffer.Metrics) error{Stop}!void {
+        const line_width = root.line_width(cursor.row, metrics) catch 0;
+        if (cursor.col >= line_width) {
+            cursor.move_down(root, metrics) catch return;
+            cursor.move_begin();
+            return;
+        }
         move_cursor_right_until(root, cursor, is_word_boundary_right, metrics);
+        const new_line_width = root.line_width(cursor.row, metrics) catch 0;
+        if (cursor.col >= new_line_width) return;
         try move_cursor_right(root, cursor, metrics);
     }
 


### PR DESCRIPTION
I don't know if it is by design or not, but the current behavior is:

```c
// Current state
printf("Value: %d|", sum);

// Press CTRL + Right
printf("Value: %d", sum|);

// Press CTRL + Right
printf("Value: %d", sum);
| // <- Skips the newline character and lands on the next line
```

To me this feels weird, I'm used to always ending at the last character, before a new line

With this PR, the behavior is:

```c
// Current state
printf("Value: %d|", sum);

// Press CTRL + Right
printf("Value: %d", sum|); // unchanged

// Press CTRL + Right
printf("Value: %d", sum);| // <- Stops perfectly at the end of the statement
```

It mimics what other editors do (Sublime Text / VSCode), wich IMO feels better, it's more precise
