### PR TITLE
Word left stops before newline when moved from other line

### DIFF
--- a/src/tui/editor.zig
+++ b/src/tui/editor.zig
@@ -3672,6 +3672,11 @@ pub const Editor = struct {
     }
 
     pub fn move_cursor_word_left(root: Buffer.Root, cursor: *Cursor, metrics: Buffer.Metrics) error{Stop}!void {
+        if (cursor.col == 0) {
+            cursor.move_up(root, metrics) catch return;
+            cursor.move_end(root, metrics);
+            return;
+        }
         try move_cursor_left(root, cursor, metrics);
         move_cursor_left_until(root, cursor, is_word_boundary_left, metrics);
     }


### PR DESCRIPTION
This is similar to #518 but for left


Before:
```c
// Current state
printf("Value: %d", sum);
|

// Press CTRL + Left
printf("Value: %d", |sum);
                 // ^ Skips the new line character
```

After:
```c
// Current state
printf("Value: %d", sum);
|

// Press CTRL + Left
printf("Value: %d", sum);| // <- Stops perfectly at the end of the statement

// Press CTRL + Left
printf("Value: %d", |sum);
```

To me this makes more sense, allows to be precise for when one needs to put a comment on the line, or add tags on some languages

This too mimics what other editors do (Sublime Text/VSCode)