### PR TITLE
fix: invert priorities in file type guess

### DIFF
--- a/src/file_type_config.zig
+++ b/src/file_type_config.zig
@@ -167,13 +167,12 @@ pub fn guess_file_type(file_path: ?[]const u8, content: []const u8) ?@This() {
 }
 
 fn guess(file_path: ?[]const u8, content: []const u8) ?@This() {
-    if (guess_first_line(content)) |ft| return ft;
     for (get_all_names()) |file_type_name| {
         const file_type = get(file_type_name) catch unreachable orelse unreachable;
         if (file_path) |fp| if (syntax.FileType.match_file_type(file_type.extensions orelse continue, fp))
             return file_type;
     }
-    return null;
+    return guess_first_line(content);
 }
 
 fn guess_first_line(content: []const u8) ?@This() {


### PR DESCRIPTION
As discussed on Discord, Flow should first try to guess the file type by the extension, and only afterwards fallback to the first-line guess.

before (guessed bash file type, because of the leading shebang):
<img width="1280" height="708" alt="image" src="https://github.com/user-attachments/assets/391d6970-2a09-4e36-bffe-aec0cb7ea674" />

after (guessed rust file type, because of the `.rs` extension):
<img width="1280" height="708" alt="image" src="https://github.com/user-attachments/assets/0525e760-0fc2-435b-9f17-13b2e973bf8e" />

