### PR TITLE
feat: Add backtick textobject actions

### DIFF
--- a/src/keybind/builtin/vim.json
+++ b/src/keybind/builtin/vim.json
@@ -92,6 +92,7 @@
             ["di}", "cut_inside_braces"],
             ["di'", "cut_inside_single_quotes"],
             ["di\"", "cut_inside_double_quotes"],
+            ["di`", "cut_inside_backticks"],
 
             ["daw", "cut_around_word"],
             ["da(", "cut_around_parentheses"],
@@ -104,6 +105,7 @@
             ["da}", "cut_around_braces"],
             ["da'", "cut_around_single_quotes"],
             ["da\"", "cut_around_double_quotes"],
+            ["da`", "cut_around_backticks"],
 
             ["cc", ["enter_mode", "insert"], ["cut_internal_vim"]],
             ["C", ["enter_mode", "insert"], ["cut_to_end_vim"]],
@@ -122,6 +124,7 @@
             ["ci}", ["enter_mode", "insert"], ["cut_inside_braces"]],
             ["ci'", ["enter_mode", "insert"], ["cut_inside_single_quotes"]],
             ["ci\"", ["enter_mode", "insert"], ["cut_inside_double_quotes"]],
+            ["ci`", ["enter_mode", "insert"], ["cut_inside_backticks"]],
 
             ["caw", ["enter_mode", "insert"], ["cut_around_word"]],
             ["ca(", ["enter_mode", "insert"], ["cut_around_parentheses"]],
@@ -134,6 +137,7 @@
             ["ca}", ["enter_mode", "insert"], ["cut_around_braces"]],
             ["ca'", ["enter_mode", "insert"], ["cut_around_single_quotes"]],
             ["ca\"", ["enter_mode", "insert"], ["cut_around_double_quotes"]],
+            ["ca`", ["enter_mode", "insert"], ["cut_around_backticks"]],
 
             ["yy", ["copy_line_internal_vim"], ["cancel"]],
 
@@ -148,6 +152,7 @@
             ["yi}", ["copy_inside_braces"], ["cancel"]],
             ["yi'", ["copy_inside_single_quotes"], ["cancel"]],
             ["yi\"", ["copy_inside_double_quotes"], ["cancel"]],
+            ["yi`", ["copy_inside_backticks"], ["cancel"]],
 
             ["yaw", ["copy_around_word"], ["cancel"]],
             ["ya(", ["copy_around_parentheses"], ["cancel"]],
@@ -160,6 +165,7 @@
             ["ya}", ["copy_around_braces"], ["cancel"]],
             ["ya'", ["copy_around_single_quotes"], ["cancel"]],
             ["ya\"", ["copy_around_double_quotes"], ["cancel"]],
+            ["ya`", ["copy_around_backticks"], ["cancel"]],
 
             ["<C-u>", "move_scroll_half_page_up_vim"],
             ["<C-d>", "move_scroll_half_page_down_vim"],
@@ -242,6 +248,7 @@
             ["i}", "select_inside_braces"],
             ["i'", "select_inside_single_quotes"],
             ["i\"", "select_inside_double_quotes"],
+            ["i`", "select_inside_backticks"],
 
             ["aw", "select_around_word"],
             ["a(", "select_around_parentheses"],
@@ -254,6 +261,7 @@
             ["a}", "select_around_braces"],
             ["a'", "select_around_single_quotes"],
             ["a\"", "select_around_double_quotes"],
+            ["a`", "select_around_backticks"],
 
             ["^", "smart_move_begin"],
             ["$", "select_end"],

--- a/src/tui/mode/vim.zig
+++ b/src/tui/mode/vim.zig
@@ -274,6 +274,24 @@ const cmds_ = struct {
     }
     pub const select_around_double_quotes_meta: Meta = .{ .description = "Select around \"\"" };
 
+    pub fn select_inside_backticks(_: *void, _: Ctx) Result {
+        const mv = tui.mainview() orelse return;
+        const ed = mv.get_active_editor() orelse return;
+        const root = ed.buf_root() catch return;
+
+        try ed.with_cursels_const(root, select_inside_backticks_textobject, ed.metrics);
+    }
+    pub const select_inside_backticks_meta: Meta = .{ .description = "Select inside ``" };
+
+    pub fn select_around_backticks(_: *void, _: Ctx) Result {
+        const mv = tui.mainview() orelse return;
+        const ed = mv.get_active_editor() orelse return;
+        const root = ed.buf_root() catch return;
+
+        try ed.with_cursels_const(root, select_around_backticks_textobject, ed.metrics);
+    }
+    pub const select_around_backticks_meta: Meta = .{ .description = "Select around ``" };
+
     pub fn cut_inside_word(_: *void, ctx: Ctx) Result {
         const mv = tui.mainview() orelse return;
         const ed = mv.get_active_editor() orelse return;
@@ -414,6 +432,26 @@ const cmds_ = struct {
     }
     pub const cut_around_double_quotes_meta: Meta = .{ .description = "Cut around \"\"" };
 
+    pub fn cut_inside_backticks(_: *void, ctx: Ctx) Result {
+        const mv = tui.mainview() orelse return;
+        const ed = mv.get_active_editor() orelse return;
+        const root = ed.buf_root() catch return;
+
+        try ed.with_cursels_const(root, select_inside_backticks_textobject, ed.metrics);
+        try ed.cut_internal_vim(ctx);
+    }
+    pub const cut_inside_backticks_meta: Meta = .{ .description = "Cut inside ``" };
+
+    pub fn cut_around_backticks(_: *void, ctx: Ctx) Result {
+        const mv = tui.mainview() orelse return;
+        const ed = mv.get_active_editor() orelse return;
+        const root = ed.buf_root() catch return;
+
+        try ed.with_cursels_const(root, select_around_backticks_textobject, ed.metrics);
+        try ed.cut_internal_vim(ctx);
+    }
+    pub const cut_around_backticks_meta: Meta = .{ .description = "Cut around ``" };
+
     pub fn copy_inside_word(_: *void, ctx: Ctx) Result {
         const mv = tui.mainview() orelse return;
         const ed = mv.get_active_editor() orelse return;
@@ -553,6 +591,26 @@ const cmds_ = struct {
         try ed.copy_internal_vim(ctx);
     }
     pub const copy_around_double_quotes_meta: Meta = .{ .description = "Copy around \"\"" };
+
+    pub fn copy_inside_backticks(_: *void, ctx: Ctx) Result {
+        const mv = tui.mainview() orelse return;
+        const ed = mv.get_active_editor() orelse return;
+        const root = ed.buf_root() catch return;
+
+        try ed.with_cursels_const(root, select_inside_backticks_textobject, ed.metrics);
+        try ed.copy_internal_vim(ctx);
+    }
+    pub const copy_inside_backticks_meta: Meta = .{ .description = "Copy inside ``" };
+
+    pub fn copy_around_backticks(_: *void, ctx: Ctx) Result {
+        const mv = tui.mainview() orelse return;
+        const ed = mv.get_active_editor() orelse return;
+        const root = ed.buf_root() catch return;
+
+        try ed.with_cursels_const(root, select_around_backticks_textobject, ed.metrics);
+        try ed.copy_internal_vim(ctx);
+    }
+    pub const copy_around_backticks_meta: Meta = .{ .description = "Copy around ``" };
 };
 
 fn is_tab_or_space(c: []const u8) bool {
@@ -663,6 +721,14 @@ fn select_inside_double_quotes_textobject(root: Buffer.Root, cursel: *CurSel, me
 
 fn select_around_double_quotes_textobject(root: Buffer.Root, cursel: *CurSel, metrics: Buffer.Metrics) !void {
     return try select_scope_textobject(root, cursel, metrics, "\"", "\"", .around);
+}
+
+fn select_inside_backticks_textobject(root: Buffer.Root, cursel: *CurSel, metrics: Buffer.Metrics) !void {
+    return try select_scope_textobject(root, cursel, metrics, "`", "`", .inside);
+}
+
+fn select_around_backticks_textobject(root: Buffer.Root, cursel: *CurSel, metrics: Buffer.Metrics) !void {
+    return try select_scope_textobject(root, cursel, metrics, "`", "`", .around);
 }
 
 fn select_scope_textobject(


### PR DESCRIPTION
I was reminded of the backtick textobject when I reread the original issue for these additions. It works, but I noticed some unrelated transient error (something related to "incremental syntax update [number] errors -> full reparse") that triggers when typing backticks (and is independent of the edits made by this PR). It doesn't seem to break anything, but I just wanted to note it. 

 If I have time later this week I'll try to get the last few textobjects in as well, unless someone else wants to have some fun with it.