### PR TITLE
fix: detect_indent_size inconsistent return caused division by zero

### DIFF
--- a/src/buffer/Buffer.zig
+++ b/src/buffer/Buffer.zig
@@ -1409,7 +1409,7 @@ fn detect_indent_size(leaves: []const Node) ?usize {
     for (leaves) |leaf_node| {
         const line = leaf_node.leaf.buf;
         if (line.len == 0) continue;
-        if (line[0] == '\t') return 0;
+        if (line[0] == '\t') return null;
         var spaces: usize = 0;
         for (line) |c| {
             if (c == ' ') spaces += 1 else break;


### PR DESCRIPTION
Initially got my attention by:

```
thread 161113 panic: division by zero
flow/src/tui/editor.zig:4508:106: 0x8bd4068 in indent_cursor (flow)
                const cols = self.indent_size - find_first_non_ws(root, cursel.cursor.row, self.metrics) % self.indent_size;
```

Turns out for some unfortunate files that contain a stray tab `detect_indent_size` returns 0 instead of null.
Edit: or in fact a file with no leading space other than tabs.