### PR TITLE
feat: add_cursor_prev_match command

### DIFF
--- a/src/keybind/builtin/flow.json
+++ b/src/keybind/builtin/flow.json
@@ -110,6 +110,7 @@
             ["ctrl+f", "find"],
             ["ctrl+g", "goto"],
             ["ctrl+d", "add_cursor_next_match"],
+            ["alt+d", "add_cursor_prev_match"],
             ["ctrl+a", "select_all"],
             ["ctrl+i", "insert_chars", "\t"],
             ["ctrl+/", "toggle_comment"],

--- a/src/keybind/builtin/flow.json
+++ b/src/keybind/builtin/flow.json
@@ -75,10 +75,10 @@
             ["f7", ["create_scratch_buffer", "*build*"], ["shell_execute_insert", "zig", "build"]],
             ["ctrl+f6", "open_version_info"],
             ["alt+shift+t", "set_session_tab_width"],
-            ["alt+d", ["shell_execute_insert", "date", "--iso-8601"]],
+            ["ctrl+k d", ["shell_execute_insert", "date", "--iso-8601"]],
             ["alt+=", "expand_centered_view"],
             ["alt+-", "shrink_centered_view"],
-            ["ctrl+alt+shift+d", ["shell_execute_insert", "date", "--iso-8601=seconds"]]
+            ["ctrl+k D", ["shell_execute_insert", "date", "--iso-8601=seconds"]]
         ]
     },
     "normal": {

--- a/src/tui/editor.zig
+++ b/src/tui/editor.zig
@@ -4188,6 +4188,30 @@ pub const Editor = struct {
     }
     pub const add_cursor_next_match_meta: Meta = .{ .description = "Add cursor at next highlighted match", .arguments = &.{.integer} };
 
+    pub fn add_cursor_prev_match(self: *Self, ctx: Context) Result {
+        try self.send_editor_jump_source();
+        var repeat: usize = 1;
+        _ = ctx.args.match(.{tp.extract(&repeat)}) catch false;
+        while (repeat > 0) : (repeat -= 1) {
+            if (self.matches.items.len == 0) {
+                const root = self.buf_root() catch return;
+                self.with_cursors_const_once(root, move_cursor_word_begin) catch {};
+                try self.with_selections_const_once(root, move_cursor_word_end);
+            } else if (self.get_prev_match(self.get_primary().cursor)) |match| {
+                if (self.get_primary().selection) |_|
+                    try self.push_cursor();
+                const primary = self.get_primary();
+                const root = self.buf_root() catch return;
+                primary.selection = match.to_selection();
+                match.has_selection = true;
+                primary.cursor.move_to(root, match.end.row, match.end.col, self.metrics) catch return;
+            }
+        }
+        self.clamp();
+        try self.send_editor_jump_destination();
+    }
+    pub const add_cursor_prev_match_meta: Meta = .{ .description = "Add cursor at previous highlighted match", .arguments = &.{.integer} };
+
     pub fn add_cursor_all_matches(self: *Self, _: Context) Result {
         if (self.matches.items.len == 0) return;
         try self.send_editor_jump_source();


### PR DESCRIPTION
I use my own keymap and do not know of other editors' bindings, so I left the command unbound for now.