### PR TITLE
feat: {move,select}_par_{begin,end} select_par

### DIFF
--- a/src/tui/editor.zig
+++ b/src/tui/editor.zig
@@ -4858,6 +4858,76 @@ pub const Editor = struct {
     }
     pub const move_buffer_end_meta: Meta = .{ .description = "Move cursor to end of file" };
 
+    fn move_cursor_to_next_empty_line(root: Buffer.Root, cursor: *Cursor, metrics: Buffer.Metrics) !void {
+        var seen_popd = false;
+        while (true) {
+            const line_width = root.line_width(cursor.row, metrics) catch return;
+            if (line_width > 0)
+                seen_popd = true
+            else if (seen_popd)
+                return;
+            cursor.move_down(root, metrics) catch |e| switch (e) {
+                error.Stop => {
+                    cursor.move_end(root, metrics);
+                    return;
+                },
+            };
+        }
+    }
+
+    fn move_cursor_to_prev_empty_line(root: Buffer.Root, cursor: *Cursor, metrics: Buffer.Metrics) !void {
+        var seen_popd = false;
+        while (true) {
+            const line_width = root.line_width(cursor.row, metrics) catch return;
+            if (line_width > 0)
+                seen_popd = true
+            else if (seen_popd)
+                return;
+            cursor.move_up(root, metrics) catch |e| switch (e) {
+                error.Stop => {
+                    cursor.move_begin();
+                    return;
+                },
+            };
+        }
+    }
+
+    pub fn move_par_end(self: *Self, ctx: Context) Result {
+        const root = try self.buf_root();
+        self.with_cursors_const_repeat(root, move_cursor_to_next_empty_line, ctx) catch {};
+        self.clamp();
+    }
+    pub const move_par_end_meta: Meta = .{ .description = "Move to end of paragraph", .arguments = &.{.integer} };
+
+    pub fn move_par_begin(self: *Self, ctx: Context) Result {
+        const root = try self.buf_root();
+        self.with_cursors_const_repeat(root, move_cursor_to_prev_empty_line, ctx) catch {};
+        self.clamp();
+    }
+    pub const move_par_begin_meta: Meta = .{ .description = "Move to beginning of paragraph", .arguments = &.{.integer} };
+
+    pub fn select_par_end(self: *Self, ctx: Context) Result {
+        const root = try self.buf_root();
+        self.with_selections_const_repeat(root, move_cursor_to_next_empty_line, ctx) catch {};
+        self.clamp();
+    }
+    pub const select_par_end_meta: Meta = .{ .description = "Select to end of paragraph", .arguments = &.{.integer} };
+
+    pub fn select_par_begin(self: *Self, ctx: Context) Result {
+        const root = try self.buf_root();
+        self.with_selections_const_repeat(root, move_cursor_to_prev_empty_line, ctx) catch {};
+        self.clamp();
+    }
+    pub const select_par_begin_meta: Meta = .{ .description = "Select to beginning of paragraph", .arguments = &.{.integer} };
+
+    pub fn select_par(self: *Self, ctx: Context) Result {
+        const root = try self.buf_root();
+        self.with_cursors_const_once(root, move_cursor_to_prev_empty_line) catch {};
+        self.with_selections_const_repeat(root, move_cursor_to_next_empty_line, ctx) catch {};
+        self.clamp();
+    }
+    pub const select_par_meta: Meta = .{ .description = "Select paragraph", .arguments = &.{.integer} };
+
     pub fn cancel(self: *Self, _: Context) Result {
         self.clear_info_box();
         self.cancel_all_tabstops();


### PR DESCRIPTION
These commands are very helpful (but not exclusively) for all text-like modes (includings typst and latex, for example).
"Paragraphs" are hardcoded as empty lines -- this should be fine in practice, and any generalization would need something much more complex (emacs-like regex stuff).

I browsed the source for inspiration on the proper way to implement this, but I am still not 100% sure.  I have manually tested some ugly edge cases and interaction with multiple cursors/selections.
Also, the code may be better at another place?  It made sense to me to keep internals and all the commands together.

Default emacs bindings would be
```json
            ["alt+{", "move_par_begin"],
            ["alt+}", "move_par_end"],
            ["alt+h", "select_par"],
```
in normal mode, and
```json
            ["alt+{", "select_par_begin"],
            ["alt+}", "select_par_end"],
```
in select.  However, the move commands are bound to tree-sitter currently, and alt+h I could, weirdly, not get to work; so I decided to rather not mess with key bindings at all (again).