### PR TITLE
fix(build): avoid forcing LLD on Darwin

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -339,7 +339,7 @@ pub fn build_exe(
         .target = target,
         .optimize = optimize_deps,
         .use_tree_sitter = use_tree_sitter,
-        .@"use-llvm" = use_llvm,
+        .@"use-llvm" = if (b.graph.host.result.os.tag.isDarwin()) null else use_llvm,
     });
     const syntax_mod = syntax_dep.module("syntax");
 
@@ -865,7 +865,7 @@ pub fn build_exe(
 
     if (use_llvm) |value| {
         exe.use_llvm = value;
-        exe.use_lld = value;
+        exe.use_lld = value and !target.result.os.tag.isDarwin();
     }
 
     if (pie) |value| exe.pie = value;
@@ -966,7 +966,7 @@ pub fn build_exe(
             .strip = strip,
         }),
         .use_llvm = use_llvm,
-        .use_lld = use_llvm,
+        .use_lld = if (use_llvm) |value| value and !target.result.os.tag.isDarwin() else null,
         .filters = test_filters,
     });
 

--- a/build.zig
+++ b/build.zig
@@ -249,6 +249,8 @@ pub fn build_exe(
     version: []const u8,
     test_filters: []const []const u8,
 ) void {
+    const use_lld = if (use_llvm) |value| value and !target.result.os.tag.isDarwin() else null;
+
     const options = b.addOptions();
     options.addOption(bool, "enable_tracy", tracy_enabled);
     options.addOption(bool, "use_tree_sitter", use_tree_sitter);
@@ -865,7 +867,7 @@ pub fn build_exe(
 
     if (use_llvm) |value| {
         exe.use_llvm = value;
-        exe.use_lld = value and !target.result.os.tag.isDarwin();
+        exe.use_lld = use_lld.?;
     }
 
     if (pie) |value| exe.pie = value;
@@ -966,7 +968,7 @@ pub fn build_exe(
             .strip = strip,
         }),
         .use_llvm = use_llvm,
-        .use_lld = if (use_llvm) |value| value and !target.result.os.tag.isDarwin() else null,
+        .use_lld = use_lld,
         .filters = test_filters,
     });
 


### PR DESCRIPTION
Avoid forcing LLD when building on or for Darwin.

- Set `use_lld` only when LLVM is enabled and the output target is not Darwin.
- Avoid passing `use-llvm` to `flow-syntax` on Darwin hosts, because its build-time query generator runs on the host and maps `use_llvm` directly to `use_lld`.