### PR TITLE
fix: guard against zero screen dimensions in cell_x/cell_y

### DIFF
--- a/src/renderer/vaxis/Plane.zig
+++ b/src/renderer/vaxis/Plane.zig
@@ -117,12 +117,14 @@ pub inline fn dim_x(self: Plane) u31 {
 }
 
 pub inline fn cell_x(self: Plane) u16 {
+    if (self.window.screen.width == 0) return 0;
     const xextra = self.window.screen.width_pix % self.window.screen.width;
     const xcell = (self.window.screen.width_pix - xextra) / self.window.screen.width;
     return xcell;
 }
 
 pub inline fn cell_y(self: Plane) u16 {
+    if (self.window.screen.height == 0) return 0;
     const yextra = self.window.screen.height_pix % self.window.screen.height;
     const ycell = (self.window.screen.height_pix - yextra) / self.window.screen.height;
     return ycell;


### PR DESCRIPTION
On startup with Ghostty, flow crashes with a division by zero:

> thread 288301 panic: division by zero
> /src/renderer/vaxis/Plane.zig:127:60:
>         const ycell = (self.window.screen.height_pix - yextra) / self.window.screen.height;

cell_y and cell_x are called during tui.init before terminal dimensions are known