### PR TITLE
fix: use indent instead of indent_at for Tab in vim insert mode

### DIFF
--- a/src/tui/editor.zig
+++ b/src/tui/editor.zig
@@ -4696,11 +4696,12 @@ pub const Editor = struct {
     }
 
     pub fn indent_at(self: *Self, ctx: Context) Result {
+        if (self.pop_tabstop()) return;
         const b = try self.buf_for_update();
         const root = try self.with_cursels_mut_repeat(b.root, indent_at_cursel, b.allocator, ctx);
         try self.update_buf(root, ctx.now);
     }
-    pub const indent_at_meta: Meta = .{ .description = "Add indentation at cursor", .arguments = &.{.integer} };
+    pub const indent_at_meta: Meta = .{ .description = "Add indentation at cursor (or pop tabstop)", .arguments = &.{.integer} };
 
     fn indent_cursor(self: *Self, root_: Buffer.Root, cursor: Cursor, no_blank_line: bool, allocator: Allocator) error{Stop}!Buffer.Root {
         const space = "                                ";


### PR DESCRIPTION
indent_at always inserts indentation, indent correctly handles snippet tabstop navigation first, falling back to indentation when no active tabstops are present.

Fixes Tab key not advancing to next snippet placeholder in vim insert mode.