### PR TITLE
fix: use root plane cell size in WidgetList.build_trailing_target

### DIFF
--- a/src/tui/WidgetList.zig
+++ b/src/tui/WidgetList.zig
@@ -263,8 +263,8 @@ fn build_trailing_target(self: *Self, layer: *Layer, client_box: *const Widget.B
     if (self.plane.layer) |plane_layer| target.z_index = @enumFromInt(@intFromEnum(plane_layer.z_index) + 1);
     layer.z_index = target.z_index; // keep in sync
 
-    const cw = self.plane.cell_x();
-    const ch = self.plane.cell_y();
+    const cw = tui.plane().cell_x();
+    const ch = tui.plane().cell_y();
     var parent_ox: i32 = 0;
     var parent_oy: i32 = 0;
     if (self.plane.layer) |l| parent_ox, parent_oy = l.global_origin_px();


### PR DESCRIPTION
For single-row layers such as the bottom status bar, self.plane.cell_y() returns screen.height_pix / screen.height = (1 * ch + extra_y) / 1 = ch + extra_y, which is larger than the true character height ch. This inflates every pixel-to-cell division in build_trailing_target, causing the trailing (right-aligned) static widgets to be placed at a row offset that varies with window size.

Switch to tui.plane().cell_x() / cell_y() to always use the root plane's correct cell dimensions, independent of any per-layer pixel padding.