### PR TITLE
Add/update configs for a few languages

### DIFF
--- a/src/file_type_lsp.zig
+++ b/src/file_type_lsp.zig
@@ -183,7 +183,7 @@ pub const ninja = .{};
 
 pub const nix = .{
     .language_server = .{"nixd"},
-    .formatter = .{"alejandra"},
+    .formatter = .{ "alejandra", "-q" },
 };
 
 pub const nu = .{

--- a/src/file_type_lsp.zig
+++ b/src/file_type_lsp.zig
@@ -13,6 +13,21 @@ pub const bash = .{
     .formatter = .{ "shfmt", "--indent", "4" },
 };
 
+pub const bibtex = .{
+    .language_server = .{"texlab"},
+    .formatter = .{
+        "bibtex-tidy",
+        "-",
+        "--curly",
+        "--drop-all-caps",
+        "--remove-empty-fields",
+        "--sort-fields",
+        "--sort=year,author,id",
+        "--strip-enclosing-braces",
+        "--trailing-commas",
+    },
+};
+
 pub const c = .{
     .language_server = .{"clangd"},
     .formatter = .{"clang-format"},

--- a/src/file_type_lsp.zig
+++ b/src/file_type_lsp.zig
@@ -285,6 +285,12 @@ pub const zig = .{
     .formatter = .{ "zig", "fmt", "--stdin" },
 };
 
-pub const ziggy = .{};
+pub const ziggy = .{
+    .language_server = .{ "ziggy", "lsp" },
+    .formatter = .{ "ziggy", "fmt", "--stdin" },
+};
 
-pub const @"ziggy-schema" = .{};
+pub const @"ziggy-schema" = .{
+    .language_server = .{ "ziggy", "lsp", "--schema" },
+    .formatter = .{ "ziggy", "fmt", "--stdin-schema" },
+};

--- a/src/file_type_lsp.zig
+++ b/src/file_type_lsp.zig
@@ -125,6 +125,10 @@ pub const julia = .{
     .formatter = .{ "julia", "-e", "using JuliaFormatter; print(format_text(read(stdin, String)))" },
 };
 
+pub const just = .{
+    .language_server = .{"just-lsp"},
+};
+
 pub const kdl = .{
     .formatter = .{ "kdlfmt", "format", "-" },
 };

--- a/src/file_type_lsp.zig
+++ b/src/file_type_lsp.zig
@@ -133,6 +133,11 @@ pub const kdl = .{
     .formatter = .{ "kdlfmt", "format", "-" },
 };
 
+pub const latex = .{
+    .language_server = .{"texlab"},
+    .formatter = .{ "tex-fmt", "--stdin" },
+};
+
 pub const lua = .{
     .language_server = .{"lua-language-server"},
     .formatter = .{ "stylua", "--indent-type", "{{indent_mode}}", "--indent-width", "{{indent_size}}", "-" },


### PR DESCRIPTION
I think those are pretty standard choices -- I mostly looked into which ones Helix has configured.

- [`texlab`](https://github.com/latex-lsp/texlab) (LSP) for LaTeX and BibTeX
- [`bibtex-tidy`](https://github.com/FlamingTempura/bibtex-tidy) (formatter) for BibTeX
- [`just-lsp`](https://github.com/terror/just-lsp) (LSP) for `just`
- [`ziggy`](https://github.com/kristoff-it/ziggy) (LSP & formatter) for `ziggy` and `ziggy-schema`

`bibtex-tidy`’s arguments were also picked from Helix. I don’t have strong opinions on them but they look sane. I should note that the tool doesn’t seem to support config files so it’d be complicated to configure it in another way in `flow`.

Depends on https://github.com/neurocyte/flow-syntax/pull/28