### PR TITLE
fix: nvim bindings syntax are not accepted

### DIFF
--- a/src/keybind/builtin/vim.json
+++ b/src/keybind/builtin/vim.json
@@ -463,22 +463,22 @@
     },
     "overlay/palette": {
         "press": [
-            ["<C-w>", "overlay_delete_word_left"]
+            ["ctrl+w", "overlay_delete_word_left"]
         ]
     },
     "mini/file_browser": {
         "press": [
-            ["<C-w>", "mini_mode_delete_to_previous_path_segment"]
+            ["ctrl+w", "mini_mode_delete_to_previous_path_segment"]
         ]
     },
     "mini/find": {
         "press": [
-            ["<C-w>", "mini_mode_delete_word_left"]
+            ["ctrl+w", "mini_mode_delete_word_left"]
         ]
     },
     "mini/find_in_files": {
         "press": [
-            ["<C-w>", "mini_mode_delete_word_left"]
+            ["ctrl+w", "mini_mode_delete_word_left"]
         ]
     },
     "home": {


### PR DESCRIPTION
In vim.json, nvim binding syntax such as "<C-w>" is accepted for vim related items.

However, in the same file, but under non-vim section such as "mini/find_in_files", this syntax is not accepted. This commit uses the syntax "ctrl+w" (consistent with flow mode or helix mode) for such sections.

This behavior is surprising (admittedly when populating vim.json in a previous commit I did not smoke test the non-vim sections), so perhaps a better long term solution would be to accept "<C-w>" syntax everywhere in vim.json, or simply requires "ctrl+w" globally.