### PR TITLE
Expanding coverage to Helix keybindings that are not implemented

### DIFF
--- a/src/tui/mode/helix.zig
+++ b/src/tui/mode/helix.zig
@@ -452,7 +452,7 @@ const cmds_ = struct {
         if (std.mem.eql(u8, action, "w")) {
             try ed.with_cursels_const(root, select_around_word, ed.metrics);
         } else if (std.mem.eql(u8, action, "W")) {
-            try ed.with_cursels_const(root, select_inner_long_word, ed.metrics);
+            try ed.with_cursels_const(root, select_around_long_word, ed.metrics);
         } else {
             return;
         }
@@ -679,10 +679,10 @@ fn select_around_word(root: Buffer.Root, cursel: *CurSel, metrics: Buffer.Metric
 }
 
 fn select_around_long_word(root: Buffer.Root, cursel: *CurSel, metrics: Buffer.Metrics) !void {
-    if (!cursel.cursor.test_at(root, Editor.is_word_char, metrics)) return;
+    if (cursel.cursor.test_at(root, Editor.is_whitespace, metrics)) return;
     var expander = cursel.*;
     try select_inner_long_word(root, &expander, metrics);
-    const sel_e = try expander.enable_selection(root, metrics);
+    const sel_e = expander.enable_selection(root, metrics);
     var prev = sel_e.begin;
     var next = sel_e.end;
     if (next.test_at(root, is_tab_or_space, metrics)) {
@@ -697,7 +697,7 @@ fn select_around_long_word(root: Buffer.Root, cursel: *CurSel, metrics: Buffer.M
             prev = sel_e.begin;
         }
     }
-    const sel = try cursel.enable_selection(root, metrics);
+    const sel = cursel.enable_selection(root, metrics);
     sel.begin = prev;
     sel.end = next;
     cursel.*.cursor = next;

--- a/src/tui/mode/helix.zig
+++ b/src/tui/mode/helix.zig
@@ -8,6 +8,7 @@ const cmd = command.executeName;
 
 const tui = @import("../tui.zig");
 const Editor = @import("../editor.zig").Editor;
+const bracket_search_radius = @import("../editor.zig").bracket_search_radius;
 const CurSel = @import("../editor.zig").CurSel;
 const Buffer = @import("Buffer");
 const Cursor = Buffer.Cursor;
@@ -423,8 +424,10 @@ const cmds_ = struct {
             try ed.with_cursels_const(root, select_inner_word, ed.metrics);
         } else if (std.mem.eql(u8, action, "W")) {
             try ed.with_cursels_const(root, select_inner_long_word, ed.metrics);
-        } else {
+        } else if (is_reserved_textobject(action)) {
             return;
+        } else {
+            try ed.with_cursels_const_once_arg(root, &select_scope_inner_cursel, ctx);
         }
         ed.clamp(ctx.now);
     }
@@ -453,8 +456,10 @@ const cmds_ = struct {
             try ed.with_cursels_const(root, select_around_word, ed.metrics);
         } else if (std.mem.eql(u8, action, "W")) {
             try ed.with_cursels_const(root, select_around_long_word, ed.metrics);
-        } else {
+        } else if (is_reserved_textobject(action)) {
             return;
+        } else {
+            try ed.with_cursels_const_once_arg(root, &select_scope_around_cursel, ctx);
         }
         ed.clamp(ctx.now);
     }
@@ -874,6 +879,132 @@ fn replace_cursel_with_character(ed: *Editor, root: Buffer.Root, cursel: *CurSel
     for (0..sel_length) |i|
         @memcpy(replacement[i * egc.len .. (i + 1) * egc.len], egc);
     return insert_replace_selection(ed, root, cursel, replacement, allocator) catch return error.Stop;
+}
+
+// Textobject keys helix resolves through tree-sitter queries (paragraph,
+// function, type, argument, comment, test, change, closest pair). Flow has no
+// query-based textobjects, so these stay no-ops instead of being misread as
+// same-character pairs.
+fn is_reserved_textobject(action: []const u8) bool {
+    return action.len == 1 and std.mem.indexOfScalar(u8, "pftacTgm", action[0]) != null;
+}
+
+const TextObjectScope = enum { inside, around };
+
+fn select_scope_cursel(root: Buffer.Root, cursel: *CurSel, ctx: command.Context, metrics: Buffer.Metrics, scope: TextObjectScope) error{Stop}!void {
+    var egc: []const u8 = undefined;
+    if (!(ctx.args.match(.{tp.extract(&egc)}) catch return error.Stop))
+        return error.Stop;
+    const pair = find_open_close_pair(egc);
+    try select_scope_textobject(root, cursel, metrics, pair.left, pair.right, scope);
+}
+
+fn select_scope_inner_cursel(root: Buffer.Root, cursel: *CurSel, ctx: command.Context, metrics: Buffer.Metrics) error{Stop}!void {
+    return select_scope_cursel(root, cursel, ctx, metrics, .inside);
+}
+
+fn select_scope_around_cursel(root: Buffer.Root, cursel: *CurSel, ctx: command.Context, metrics: Buffer.Metrics) error{Stop}!void {
+    return select_scope_cursel(root, cursel, ctx, metrics, .around);
+}
+
+// Select inside or around the pair enclosing the cursor. Same-character
+// pairs (quotes) resolve via Editor.find_quote_pair, which skips escaped
+// delimiters; distinct pairs resolve via Editor.match_bracket, searching
+// outward when the cursor is not on a delimiter itself. Leaves the cursor
+// at the end of the selection.
+fn select_scope_textobject(
+    root: Buffer.Root,
+    cursel: *CurSel,
+    metrics: Buffer.Metrics,
+    opening_char: []const u8,
+    closing_char: []const u8,
+    scope: TextObjectScope,
+) error{Stop}!void {
+    const current = cursel.cursor;
+    var prev = cursel.cursor;
+    var next = cursel.cursor;
+
+    if (std.mem.eql(u8, opening_char, closing_char)) {
+        const opening_pos, const closing_pos =
+            try Editor.find_quote_pair(root, current, metrics, opening_char);
+
+        prev.row = opening_pos[0];
+        prev.col = opening_pos[1];
+        next.row = closing_pos[0];
+        next.col = closing_pos[1];
+    } else {
+        const bracket_egc, _, _ = root.egc_at(current.row, current.col, metrics) catch {
+            return error.Stop;
+        };
+
+        if (std.mem.eql(u8, bracket_egc, opening_char)) {
+            const closing_row, const closing_col =
+                try Editor.match_bracket(root, current, metrics);
+
+            prev = current;
+            next.row = closing_row;
+            next.col = closing_col;
+        } else if (std.mem.eql(u8, bracket_egc, closing_char)) {
+            const opening_row, const opening_col =
+                try Editor.match_bracket(root, current, metrics);
+
+            prev.row = opening_row;
+            prev.col = opening_col;
+            next = current;
+        } else {
+            const pair = find_bracket_pair(root, cursel, metrics, .left, opening_char) catch blk: {
+                break :blk try find_bracket_pair(root, cursel, metrics, .right, opening_char);
+            };
+
+            prev.row = pair[0][0];
+            prev.col = pair[0][1];
+            next.row = pair[1][0];
+            next.col = pair[1][1];
+        }
+    }
+
+    prev.move_right(root, metrics) catch {};
+
+    if (scope == .around) {
+        prev.move_left(root, metrics) catch {};
+        next.move_right(root, metrics) catch {};
+    }
+
+    cursel.selection = Selection{ .begin = prev, .end = next };
+    cursel.*.cursor = next;
+}
+
+fn find_bracket_pair(root: Buffer.Root, cursel: *CurSel, metrics: Buffer.Metrics, direction: enum { left, right }, char: []const u8) error{Stop}!struct { struct { usize, usize }, struct { usize, usize } } {
+    const start = cursel.cursor;
+    var moving_cursor = cursel.cursor;
+
+    var i: usize = 0;
+    while (i < bracket_search_radius) : (i += 1) {
+        switch (direction) {
+            .left => try moving_cursor.move_left(root, metrics),
+            .right => try moving_cursor.move_right(root, metrics),
+        }
+
+        const curr_egc, _, _ = root.egc_at(moving_cursor.row, moving_cursor.col, metrics) catch {
+            return error.Stop;
+        };
+        if (std.mem.eql(u8, char, curr_egc)) {
+            const closing_row, const closing_col = try Editor.match_bracket(root, moving_cursor, metrics);
+
+            switch (direction) {
+                .left => if (closing_row > start.row or (closing_row == start.row and closing_col > start.col)) {
+                    return .{ .{ moving_cursor.row, moving_cursor.col }, .{ closing_row, closing_col } };
+                } else {
+                    continue;
+                },
+                .right => {
+                    return .{ .{ moving_cursor.row, moving_cursor.col }, .{ closing_row, closing_col } };
+                },
+            }
+        }
+    }
+
+    return error.Stop;
 }
 
 fn find_open_close_pair(bracket: []const u8) struct { left: []const u8, right: []const u8 } {
@@ -1322,4 +1453,6 @@ pub const test_internal = struct {
     pub const insert_before = private.insert_before;
     pub const insert_replace_selection = private.insert_replace_selection;
     pub const insert_after = private.insert_after;
+    pub const select_scope_textobject = private.select_scope_textobject;
+    pub const TextObjectScope = private.TextObjectScope;
 };

--- a/test/annotation.zig
+++ b/test/annotation.zig
@@ -1,0 +1,233 @@
+//! Helix-style selection annotations for test fixtures.
+//!
+//! A fixture is the document text with the primary selection marked inline,
+//! using the same syntax as helix's test suite (helix-core/src/test.rs), so
+//! upstream helix test cases can be transcribed verbatim:
+//!
+//!   #[foo|]#   selection covering "foo", head after the anchor (forward)
+//!   #[|foo]#   selection covering "foo", head before the anchor (reversed)
+//!   #[|]#      zero-width cursor
+//!
+//! `parse` strips the markers and returns the plain text plus the anchor and
+//! head positions; `render` reinserts markers, so a whole assertion is one
+//! `expectEqualStrings` and a failure shows the full annotated document.
+//!
+//! Positions are (row, col) in characters. ASCII fixtures only: columns are
+//! byte offsets within the line, matching the identity metrics the flow test
+//! suite uses.
+//!
+//! A malformed fixture is always a hard error, never a best-effort parse.
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
+pub const Pos = struct {
+    row: usize,
+    col: usize,
+
+    pub fn before(self: Pos, other: Pos) bool {
+        return self.row < other.row or (self.row == other.row and self.col < other.col);
+    }
+};
+
+pub const Error = error{
+    MissingSelection,
+    MultipleSelections,
+    UnterminatedSelection,
+    MalformedSelection,
+    OutOfMemory,
+};
+
+pub const Annotated = struct {
+    alloc: Allocator,
+    /// The document with markers stripped.
+    text: []u8,
+    anchor: Pos,
+    head: Pos,
+
+    pub fn deinit(self: *Annotated) void {
+        self.alloc.free(self.text);
+    }
+
+    /// The position a point cursor sits at: the start of the selection, so a
+    /// one-character selection `#[x|]#` reads as "the cursor is on x".
+    pub fn cursor(self: *const Annotated) Pos {
+        return if (self.head.before(self.anchor)) self.head else self.anchor;
+    }
+};
+
+pub fn parse(alloc: Allocator, src: []const u8) Error!Annotated {
+    var text: std.ArrayList(u8) = .empty;
+    errdefer text.deinit(alloc);
+
+    var anchor: ?Pos = null;
+    var head: ?Pos = null;
+    var open: ?Pos = null; // position where "#[" was seen
+    var reversed = false;
+
+    var pos: Pos = .{ .row = 0, .col = 0 };
+    var i: usize = 0;
+    while (i < src.len) {
+        if (std.mem.startsWith(u8, src[i..], "#[")) {
+            if (open != null) return Error.MalformedSelection;
+            if (anchor != null) return Error.MultipleSelections;
+            open = pos;
+            i += 2;
+            if (std.mem.startsWith(u8, src[i..], "|")) {
+                reversed = true;
+                head = pos;
+                i += 1;
+            }
+            continue;
+        }
+        if (open != null and !reversed and std.mem.startsWith(u8, src[i..], "|]#")) {
+            anchor = open.?;
+            head = pos;
+            open = null;
+            i += 3;
+            continue;
+        }
+        if (open != null and reversed and std.mem.startsWith(u8, src[i..], "]#")) {
+            anchor = pos;
+            open = null;
+            i += 2;
+            continue;
+        }
+        try text.append(alloc, src[i]);
+        if (src[i] == '\n') {
+            pos.row += 1;
+            pos.col = 0;
+        } else {
+            pos.col += 1;
+        }
+        i += 1;
+    }
+
+    if (open != null) return Error.UnterminatedSelection;
+    if (anchor == null) return Error.MissingSelection;
+
+    return .{
+        .alloc = alloc,
+        .text = try text.toOwnedSlice(alloc),
+        .anchor = anchor.?,
+        .head = head.?,
+    };
+}
+
+/// Split a before/after test case on its `=>` separator line. A blank line
+/// cannot be the separator: fixture documents may contain blank lines.
+pub fn splitCase(src: []const u8) error{ MissingSeparator, MultipleSeparators }!struct {
+    input: []const u8,
+    expected: []const u8,
+} {
+    const sep = "\n=>\n";
+    const idx = std.mem.indexOf(u8, src, sep) orelse return error.MissingSeparator;
+    if (std.mem.indexOfPos(u8, src, idx + sep.len, sep) != null) return error.MultipleSeparators;
+    return .{ .input = src[0..idx], .expected = src[idx + sep.len ..] };
+}
+
+/// Both positions must lie within `text`; one past the final character is
+/// the highest valid position.
+pub fn render(alloc: Allocator, text: []const u8, anchor: Pos, head: Pos) Allocator.Error![]u8 {
+    const forward = !head.before(anchor);
+    const first = if (forward) anchor else head;
+    const last = if (forward) head else anchor;
+    const first_off = posToOffset(text, first) orelse unreachable;
+    const last_off = posToOffset(text, last) orelse unreachable;
+
+    var out: std.ArrayList(u8) = .empty;
+    errdefer out.deinit(alloc);
+    try out.appendSlice(alloc, text[0..first_off]);
+    try out.appendSlice(alloc, if (forward) "#[" else "#[|");
+    try out.appendSlice(alloc, text[first_off..last_off]);
+    try out.appendSlice(alloc, if (forward) "|]#" else "]#");
+    try out.appendSlice(alloc, text[last_off..]);
+    return out.toOwnedSlice(alloc);
+}
+
+fn posToOffset(text: []const u8, pos: Pos) ?usize {
+    var cur: Pos = .{ .row = 0, .col = 0 };
+    for (text, 0..) |c, off| {
+        if (cur.row == pos.row and cur.col == pos.col) return off;
+        if (c == '\n') {
+            cur.row += 1;
+            cur.col = 0;
+        } else {
+            cur.col += 1;
+        }
+    }
+    // One past the end is a valid marker position.
+    if (cur.row == pos.row and cur.col == pos.col) return text.len;
+    return null;
+}
+
+const a = std.testing.allocator;
+
+fn expect_round_trip(src: []const u8, text: []const u8, anchor: Pos, head: Pos) !void {
+    var ann = try parse(a, src);
+    defer ann.deinit();
+    try std.testing.expectEqualStrings(text, ann.text);
+    try std.testing.expectEqual(anchor, ann.anchor);
+    try std.testing.expectEqual(head, ann.head);
+    const rendered = try render(a, ann.text, ann.anchor, ann.head);
+    defer a.free(rendered);
+    try std.testing.expectEqualStrings(src, rendered);
+}
+
+test "annotation round trips" {
+    try expect_round_trip("#[foo|]# bar", "foo bar", .{ .row = 0, .col = 0 }, .{ .row = 0, .col = 3 });
+    try expect_round_trip("f#[|oo]# bar", "foo bar", .{ .row = 0, .col = 3 }, .{ .row = 0, .col = 1 });
+    try expect_round_trip("foo #[|]#bar", "foo bar", .{ .row = 0, .col = 4 }, .{ .row = 0, .col = 4 });
+    try expect_round_trip("foo bar#[|]#", "foo bar", .{ .row = 0, .col = 7 }, .{ .row = 0, .col = 7 });
+    try expect_round_trip("one\ntw#[o\nthr|]#ee", "one\ntwo\nthree", .{ .row = 1, .col = 2 }, .{ .row = 2, .col = 3 });
+}
+
+test "splitCase" {
+    const case = try splitCase("a#[b|]#c\n=>\n#[abc|]#");
+    try std.testing.expectEqualStrings("a#[b|]#c", case.input);
+    try std.testing.expectEqualStrings("#[abc|]#", case.expected);
+    try std.testing.expectError(error.MissingSeparator, splitCase("a\n\nb"));
+    try std.testing.expectError(error.MultipleSeparators, splitCase("a\n=>\nb\n=>\nc"));
+}
+
+test "annotation rejects malformed fixtures" {
+    try std.testing.expectError(Error.MissingSelection, parse(a, "no markers"));
+    try std.testing.expectError(Error.UnterminatedSelection, parse(a, "#[foo"));
+    try std.testing.expectError(Error.MultipleSelections, parse(a, "#[a|]# #[b|]#"));
+    try std.testing.expectError(Error.MalformedSelection, parse(a, "#[a #[b|]#"));
+}
+
+fn fuzz_render_inverts_parse(_: void, smith: *std.testing.Smith) anyerror!void {
+    @disableInstrumentation();
+    // Weighted toward the marker alphabet so random inputs actually form
+    // (and nearly form) selections instead of being all plain text.
+    var buf: [256]u8 = undefined;
+    const len = smith.sliceWeightedBytes(&buf, &.{
+        .rangeAtMost(u8, 0x20, 0x7e, 2),
+        .value(u8, '#', 8),
+        .value(u8, '[', 8),
+        .value(u8, '|', 8),
+        .value(u8, ']', 8),
+        .value(u8, '\n', 4),
+        .value(u8, '\\', 2),
+    });
+    const input = buf[0..len];
+
+    // Rejecting an input is always fine; accepting one obliges render to
+    // invert parse exactly.
+    var ann = parse(a, input) catch return;
+    defer ann.deinit();
+    const rendered = try render(a, ann.text, ann.anchor, ann.head);
+    defer a.free(rendered);
+    try std.testing.expectEqualStrings(input, rendered);
+}
+
+test "annotation fuzz: render inverts parse" {
+    try std.testing.fuzz({}, fuzz_render_inverts_parse, .{ .corpus = &.{
+        "#[foo|]# bar",
+        "f#[|oo]# bar",
+        "one\ntw#[o\nthr|]#ee",
+        "#[|]#",
+        "a \"b \\\" #[c|]#\" d",
+    } });
+}

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+pub const annotation = @import("annotation.zig");
 pub const buffer = @import("tests_buffer.zig");
 pub const color = @import("tests_color.zig");
 pub const file_link = @import("tests_file_link.zig");

--- a/test/tests_helix.zig
+++ b/test/tests_helix.zig
@@ -247,68 +247,107 @@ test "to_char_right_beyond_eol" {
 // first movement is swallowed
 
 const CurSel = @import("tui").exports.editor.CurSel;
+const annotation = @import("annotation.zig");
 
-//              1111111111222222222233333
-//    01234567890123456789012345678901234
-const scope_doc: []const u8 =
-    \\foo "bar baz" (qux (inner) end) 'q'
-    \\a "b \" c" d
-;
-
-fn expect_scope_selection(
-    root: Buffer.Root,
-    row: usize,
-    col: usize,
+// A case is one annotated document (annotation.zig): the input, a line that
+// is exactly `=>`, then the same document with the expected selection. The
+// input's selection marks where the cursor sits.
+fn expect_scope_textobject(
     open: []const u8,
     close: []const u8,
     scope: helix.test_internal.TextObjectScope,
-    begin: struct { usize, usize },
-    end: struct { usize, usize },
+    case_src: []const u8,
 ) !void {
-    var cursel: CurSel = .{ .cursor = Cursor{ .row = row, .col = col, .target = 0 } };
+    const now = std.Io.Clock.real.now(std.testing.io);
+    const case = try annotation.splitCase(case_src);
+    var ann = try annotation.parse(a, case.input);
+    defer ann.deinit();
+
+    const buffer = try Buffer.create(a, now);
+    defer buffer.deinit();
+    buffer.update(try buffer.load_from_string(ann.text, &eol_mode, &sanitized), now);
+    const root: Buffer.Root = buffer.root;
+
+    const cur = ann.cursor();
+    var cursel: CurSel = .{ .cursor = Cursor{ .row = cur.row, .col = cur.col, .target = 0 } };
     try helix.test_internal.select_scope_textobject(root, &cursel, metrics(), open, close, scope);
     const sel = cursel.selection orelse return error.TestExpectedSelection;
-    try std.testing.expectEqual(begin[0], sel.begin.row);
-    try std.testing.expectEqual(begin[1], sel.begin.col);
-    try std.testing.expectEqual(end[0], sel.end.row);
-    try std.testing.expectEqual(end[1], sel.end.col);
     try std.testing.expectEqual(sel.end.row, cursel.cursor.row);
     try std.testing.expectEqual(sel.end.col, cursel.cursor.col);
+
+    const rendered = try annotation.render(
+        a,
+        ann.text,
+        .{ .row = sel.begin.row, .col = sel.begin.col },
+        .{ .row = sel.end.row, .col = sel.end.col },
+    );
+    defer a.free(rendered);
+    try std.testing.expectEqualStrings(case.expected, rendered);
 }
 
 test "scope_textobjects" {
-    const now = std.Io.Clock.real.now(std.testing.io);
-    const buffer = try Buffer.create(a, now);
-    defer buffer.deinit();
-    buffer.update(try buffer.load_from_string(scope_doc, &eol_mode, &sanitized), now);
-    const root: Buffer.Root = buffer.root;
-
-    // inside double quotes, cursor mid-string
-    try expect_scope_selection(root, 0, 7, "\"", "\"", .inside, .{ 0, 5 }, .{ 0, 12 });
-    // around double quotes includes the delimiters
-    try expect_scope_selection(root, 0, 7, "\"", "\"", .around, .{ 0, 4 }, .{ 0, 13 });
-    // cursor on the opening quote itself
-    try expect_scope_selection(root, 0, 4, "\"", "\"", .inside, .{ 0, 5 }, .{ 0, 12 });
-    // nested parens: innermost pair wins
-    try expect_scope_selection(root, 0, 21, "(", ")", .inside, .{ 0, 20 }, .{ 0, 25 });
-    // between the pairs: outer pair
-    try expect_scope_selection(root, 0, 16, "(", ")", .inside, .{ 0, 15 }, .{ 0, 30 });
-    try expect_scope_selection(root, 0, 16, "(", ")", .around, .{ 0, 14 }, .{ 0, 31 });
-    // cursor on a delimiter
-    try expect_scope_selection(root, 0, 14, "(", ")", .inside, .{ 0, 15 }, .{ 0, 30 });
-    try expect_scope_selection(root, 0, 30, "(", ")", .inside, .{ 0, 15 }, .{ 0, 30 });
-    // escaped quote inside the string is not a delimiter
-    try expect_scope_selection(root, 1, 8, "\"", "\"", .inside, .{ 1, 3 }, .{ 1, 9 });
+    try expect_scope_textobject("\"", "\"", .inside,
+        \\foo "ba#[r|]# baz" (qux (inner) end)
+        \\=>
+        \\foo "#[bar baz|]#" (qux (inner) end)
+    );
+    try expect_scope_textobject("\"", "\"", .around,
+        \\foo "ba#[r|]# baz" (qux (inner) end)
+        \\=>
+        \\foo #["bar baz"|]# (qux (inner) end)
+    );
+    try expect_scope_textobject("\"", "\"", .inside,
+        \\foo #["|]#bar baz" (qux (inner) end)
+        \\=>
+        \\foo "#[bar baz|]#" (qux (inner) end)
+    );
+    // innermost pair wins
+    try expect_scope_textobject("(", ")", .inside,
+        \\foo "bar baz" (qux (i#[n|]#ner) end)
+        \\=>
+        \\foo "bar baz" (qux (#[inner|]#) end)
+    );
+    try expect_scope_textobject("(", ")", .inside,
+        \\foo "bar baz" (q#[u|]#x (inner) end)
+        \\=>
+        \\foo "bar baz" (#[qux (inner) end|]#)
+    );
+    try expect_scope_textobject("(", ")", .around,
+        \\foo "bar baz" (q#[u|]#x (inner) end)
+        \\=>
+        \\foo "bar baz" #[(qux (inner) end)|]#
+    );
+    try expect_scope_textobject("(", ")", .inside,
+        \\foo "bar baz" #[(|]#qux (inner) end)
+        \\=>
+        \\foo "bar baz" (#[qux (inner) end|]#)
+    );
+    try expect_scope_textobject("(", ")", .inside,
+        \\foo "bar baz" (qux (inner) end#[)|]#
+        \\=>
+        \\foo "bar baz" (#[qux (inner) end|]#)
+    );
+    // an escaped quote is not a delimiter
+    try expect_scope_textobject("\"", "\"", .inside,
+        \\foo "bar baz" (qux (inner) end)
+        \\a "b \" #[c|]#" d
+        \\=>
+        \\foo "bar baz" (qux (inner) end)
+        \\a "#[b \" c|]#" d
+    );
 }
 
 test "scope_textobjects_no_pair" {
     const now = std.Io.Clock.real.now(std.testing.io);
+    var ann = try annotation.parse(a, "a \"b c\" #[d|]#");
+    defer ann.deinit();
     const buffer = try Buffer.create(a, now);
     defer buffer.deinit();
-    buffer.update(try buffer.load_from_string(scope_doc, &eol_mode, &sanitized), now);
+    buffer.update(try buffer.load_from_string(ann.text, &eol_mode, &sanitized), now);
     const root: Buffer.Root = buffer.root;
 
-    var cursel: CurSel = .{ .cursor = Cursor{ .row = 1, .col = 11, .target = 0 } };
+    const cur = ann.cursor();
+    var cursel: CurSel = .{ .cursor = Cursor{ .row = cur.row, .col = cur.col, .target = 0 } };
     try std.testing.expectError(
         error.Stop,
         helix.test_internal.select_scope_textobject(root, &cursel, metrics(), "{", "}", .inside),

--- a/test/tests_helix.zig
+++ b/test/tests_helix.zig
@@ -245,3 +245,72 @@ test "to_char_right_beyond_eol" {
 // Related to that is the fact that when a selection
 // is made, then trying to move to the right, the
 // first movement is swallowed
+
+const CurSel = @import("tui").exports.editor.CurSel;
+
+//              1111111111222222222233333
+//    01234567890123456789012345678901234
+const scope_doc: []const u8 =
+    \\foo "bar baz" (qux (inner) end) 'q'
+    \\a "b \" c" d
+;
+
+fn expect_scope_selection(
+    root: Buffer.Root,
+    row: usize,
+    col: usize,
+    open: []const u8,
+    close: []const u8,
+    scope: helix.test_internal.TextObjectScope,
+    begin: struct { usize, usize },
+    end: struct { usize, usize },
+) !void {
+    var cursel: CurSel = .{ .cursor = Cursor{ .row = row, .col = col, .target = 0 } };
+    try helix.test_internal.select_scope_textobject(root, &cursel, metrics(), open, close, scope);
+    const sel = cursel.selection orelse return error.TestExpectedSelection;
+    try std.testing.expectEqual(begin[0], sel.begin.row);
+    try std.testing.expectEqual(begin[1], sel.begin.col);
+    try std.testing.expectEqual(end[0], sel.end.row);
+    try std.testing.expectEqual(end[1], sel.end.col);
+    try std.testing.expectEqual(sel.end.row, cursel.cursor.row);
+    try std.testing.expectEqual(sel.end.col, cursel.cursor.col);
+}
+
+test "scope_textobjects" {
+    const now = std.Io.Clock.real.now(std.testing.io);
+    const buffer = try Buffer.create(a, now);
+    defer buffer.deinit();
+    buffer.update(try buffer.load_from_string(scope_doc, &eol_mode, &sanitized), now);
+    const root: Buffer.Root = buffer.root;
+
+    // inside double quotes, cursor mid-string
+    try expect_scope_selection(root, 0, 7, "\"", "\"", .inside, .{ 0, 5 }, .{ 0, 12 });
+    // around double quotes includes the delimiters
+    try expect_scope_selection(root, 0, 7, "\"", "\"", .around, .{ 0, 4 }, .{ 0, 13 });
+    // cursor on the opening quote itself
+    try expect_scope_selection(root, 0, 4, "\"", "\"", .inside, .{ 0, 5 }, .{ 0, 12 });
+    // nested parens: innermost pair wins
+    try expect_scope_selection(root, 0, 21, "(", ")", .inside, .{ 0, 20 }, .{ 0, 25 });
+    // between the pairs: outer pair
+    try expect_scope_selection(root, 0, 16, "(", ")", .inside, .{ 0, 15 }, .{ 0, 30 });
+    try expect_scope_selection(root, 0, 16, "(", ")", .around, .{ 0, 14 }, .{ 0, 31 });
+    // cursor on a delimiter
+    try expect_scope_selection(root, 0, 14, "(", ")", .inside, .{ 0, 15 }, .{ 0, 30 });
+    try expect_scope_selection(root, 0, 30, "(", ")", .inside, .{ 0, 15 }, .{ 0, 30 });
+    // escaped quote inside the string is not a delimiter
+    try expect_scope_selection(root, 1, 8, "\"", "\"", .inside, .{ 1, 3 }, .{ 1, 9 });
+}
+
+test "scope_textobjects_no_pair" {
+    const now = std.Io.Clock.real.now(std.testing.io);
+    const buffer = try Buffer.create(a, now);
+    defer buffer.deinit();
+    buffer.update(try buffer.load_from_string(scope_doc, &eol_mode, &sanitized), now);
+    const root: Buffer.Root = buffer.root;
+
+    var cursel: CurSel = .{ .cursor = Cursor{ .row = 1, .col = 11, .target = 0 } };
+    try std.testing.expectError(
+        error.Stop,
+        helix.test_internal.select_scope_textobject(root, &cursel, metrics(), "{", "}", .inside),
+    );
+}


### PR DESCRIPTION
# Context

I'm a long time Helix user and recently I've been wanting to take an active hand in my editor experience. In part because I'm losing confidence in the Helix project's ability to address all the disparate stakeholders in a coherent way.

I saw the Flow project in passing a year ago and looked again recently. I was delighted to see the initial Helix support. The architecture seems enjoyable to work on so I've been playing around for the last few days. 

# Reviewing Helix support

My initial impression is that the keybindings represent a dump of the default helix keybindings with the missing commands being no-ops in the command registry. Seems like a good approach. Implementing a command was pretty straight forward. 

I'm opening the PR to get a sense of the intended boundaries between the `Editor` core and the vim/helix/etc drivers. I implemented the first missing command I found and it raised enough questions that it wanted to stop and ask for guidance. I don't want to create a massive PR that's off base.

1. Are there some tests that track the coverage of bindings to commands? If not, that seems like a good feedback loop to drive the work.
2. Help me understand the criteria for boundaries between the `Editor` core and the vim/helix/etc drivers. You can see I pulled up the function from vim into Editor.
3. If it's in Editor, what's the convention for function names? When in the helix module it's obvious to just copy the name 1:1 but Editor I'm not as sure.
4. My gut tells me that the duplication is not bad because I can't make a strong assertion that the vim behavior is exactly the same helix. So the attempt to reuse is premature. But then again it look like you want Editor to be a full-featured deep module and my example here of selecting a inner values is a pretty universal concept.

My last procedural question is around your preferences in PR size and scope. My intuition is PRs about this size working down the checklist for compatibility command by command.

## Support pair textobjects in mi/ma (select inside/around quotes and brackets)

Hoist vim mode's select_scope_textobject and find_bracket_pair into Editor so both modal dialects share one implementation, and wire the helix-mode select_textobject_inner/around commands to it: any non-reserved character after mi/ma now selects inside/around the matching quote or bracket pair, using the existing find_quote_pair (escape-aware) and match_bracket (nesting-aware) primitives.

Keys helix resolves through tree-sitter textobject queries (p f t a c T g m) stay no-ops rather than being misread as same-character pairs.

## Claude found these when reviewing...

Also repair the previously unreachable select_around_long_word (invalid try on enable_selection, wrong cursor guard) and bind maW to it instead of select_inner_long_word.

The selection endpoints are assigned directly instead of via enable_selection, which consults tui-global selection style state; this keeps select_scope_textobject unit-testable, with coverage added in test/tests_helix.zig.